### PR TITLE
PROBLEM: Repository naming is not updated

### DIFF
--- a/src/web/src/alert_list.ecpp
+++ b/src/web/src/alert_list.ecpp
@@ -33,7 +33,7 @@
 #include <tntdb/connection.h>
 #include <tntdb/error.h>
 
-#include <bios_proto.h>
+#include <fty_proto.h>
 #include "log.h"
 #include "utils.h"
 #include "utils_web.h"
@@ -316,44 +316,44 @@ if (streq (part, "LIST")) {
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
-%   bios_proto_t *decoded = bios_proto_decode (&decoded_zmsg);
+%   fty_proto_t *decoded = fty_proto_decode (&decoded_zmsg);
 %   if (!decoded) {
-%       log_error ("Can't decode bios_proto");
+%       log_error ("Can't decode fty_proto");
 %       zmsg_destroy (&recv_msg);
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
-%   if (!bios_proto_id (decoded) == BIOS_PROTO_ALERT) {
-%       log_error ("message id is not BIOS_PROTO_ALERT");
-%       bios_proto_destroy (&decoded);
+%   if (!fty_proto_id (decoded) == FTY_PROTO_ALERT) {
+%       log_error ("message id is not FTY_PROTO_ALERT");
+%       fty_proto_destroy (&decoded);
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
-%   if ((!checked_asset.empty () && desired_elements.find (bios_proto_element_src (decoded)) == desired_elements.end ())) {
-%       log_debug ("skipping due to element_src '%s' not being in the list", bios_proto_element_src (decoded));
-%       bios_proto_destroy (&decoded);
+%   if ((!checked_asset.empty () && desired_elements.find (fty_proto_element_src (decoded)) == desired_elements.end ())) {
+%       log_debug ("skipping due to element_src '%s' not being in the list", fty_proto_element_src (decoded));
+%       fty_proto_destroy (&decoded);
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
-%   if (!is_state_included (checked_state.c_str (), bios_proto_state (decoded))) {
-%       log_debug ("skipping due to state '%s' not being requested", bios_proto_state (decoded));
-%       bios_proto_destroy (&decoded);
+%   if (!is_state_included (checked_state.c_str (), fty_proto_state (decoded))) {
+%       log_debug ("skipping due to state '%s' not being requested", fty_proto_state (decoded));
+%       fty_proto_destroy (&decoded);
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
 %   char buff[64];
-%   rv = calendar_to_datetime (bios_proto_time (decoded), buff, 64);
+%   rv = calendar_to_datetime (fty_proto_time (decoded), buff, 64);
 %   if (rv == -1) {
-%       log_error ("can't convert %" PRIu64 "to calendar time, skipping element '%s'", bios_proto_time (decoded), bios_proto_rule (decoded) );
-%       bios_proto_destroy (&decoded);
+%       log_error ("can't convert %" PRIu64 "to calendar time, skipping element '%s'", fty_proto_time (decoded), fty_proto_rule (decoded) );
+%       fty_proto_destroy (&decoded);
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
-%   log_debug ("persist::select_asset_element_web_byName ('%s')", bios_proto_element_src (decoded));
-%   auto asset_element = persist::select_asset_element_web_byName (connection, bios_proto_element_src (decoded));
+%   log_debug ("persist::select_asset_element_web_byName ('%s')", fty_proto_element_src (decoded));
+%   auto asset_element = persist::select_asset_element_web_byName (connection, fty_proto_element_src (decoded));
 %   if (asset_element.status != 1) {
 %       log_error ("%s", asset_element.msg.c_str ());
-%       bios_proto_destroy (&decoded);
+%       fty_proto_destroy (&decoded);
 %       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
@@ -361,31 +361,31 @@ if (streq (part, "LIST")) {
 %   if (first) {
     {
         <$$ utils::json::jsonify ("timestamp", buff) $>,
-        <$$ utils::json::jsonify ("rule_name", bios_proto_rule (decoded)) $>,
+        <$$ utils::json::jsonify ("rule_name", fty_proto_rule (decoded)) $>,
         <$$ utils::json::jsonify ("element_id", std::to_string (asset_element.item.id)) $>,
-        <$$ utils::json::jsonify ("element_name", bios_proto_element_src (decoded)) $>,
+        <$$ utils::json::jsonify ("element_name", fty_proto_element_src (decoded)) $>,
         <$$ utils::json::jsonify ("element_type", asset_element.item.type_name) $>,
         <$$ utils::json::jsonify ("element_sub_type", asset_element.item.subtype_name) $>,
-        <$$ utils::json::jsonify ("state", bios_proto_state (decoded)) $>,
-        <$$ utils::json::jsonify ("severity", bios_proto_severity (decoded)) $>,
-        <$$ utils::json::jsonify ("description", bios_proto_description (decoded)) $>
+        <$$ utils::json::jsonify ("state", fty_proto_state (decoded)) $>,
+        <$$ utils::json::jsonify ("severity", fty_proto_severity (decoded)) $>,
+        <$$ utils::json::jsonify ("description", fty_proto_description (decoded)) $>
     }
 %     first = false;
 %   }
 %   else {
 , {
         <$$ utils::json::jsonify ("timestamp", buff) $>,
-        <$$ utils::json::jsonify ("rule_name", bios_proto_rule (decoded)) $>,
+        <$$ utils::json::jsonify ("rule_name", fty_proto_rule (decoded)) $>,
         <$$ utils::json::jsonify ("element_id", std::to_string (asset_element.item.id)) $>,
-        <$$ utils::json::jsonify ("element_name", bios_proto_element_src (decoded)) $>,
+        <$$ utils::json::jsonify ("element_name", fty_proto_element_src (decoded)) $>,
         <$$ utils::json::jsonify ("element_type", asset_element.item.type_name) $>,
         <$$ utils::json::jsonify ("element_sub_type", asset_element.item.subtype_name) $>,
-        <$$ utils::json::jsonify ("state", bios_proto_state (decoded)) $>,
-        <$$ utils::json::jsonify ("severity", bios_proto_severity (decoded)) $>,
-        <$$ utils::json::jsonify ("description", bios_proto_description (decoded)) $>
+        <$$ utils::json::jsonify ("state", fty_proto_state (decoded)) $>,
+        <$$ utils::json::jsonify ("severity", fty_proto_severity (decoded)) $>,
+        <$$ utils::json::jsonify ("description", fty_proto_description (decoded)) $>
 }
 %   }
-%   bios_proto_destroy (&decoded);
+%   fty_proto_destroy (&decoded);
 %   frame = zmsg_pop (recv_msg);
 % }
 ]

--- a/src/web/src/asset_GET.ecpp
+++ b/src/web/src/asset_GET.ecpp
@@ -27,6 +27,11 @@
  */
  #><%pre>
 #include <cxxtools/regex.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+
+#include <fty_proto.h>
+#include <malamute.h>
 
 #include "data.h"
 #include "asset_types.h"
@@ -36,10 +41,7 @@
 #include "helpers.h"
         
 #include "log.h"
-#include <biosproto.h>
 
-#include <sys/types.h>
-#include <sys/syscall.h>
 
 struct Outlet {
     std::string label;
@@ -83,7 +85,7 @@ s_rack_realpower_nominal (
     double ret = 0.0f;
 
     zmsg_t *request = s_rt_encode_GET (name.c_str());
-    mlm_client_sendto (client, "agent-rt", "latest-rt-data", NULL, 1000, &request);
+    mlm_client_sendto (client, "fty-metric-cache", "latest-rt-data", NULL, 1000, &request);
 
     //TODO: this intentionally wait forewer, to be fixed by proper client pool
     zmsg_t *msg = mlm_client_recv (client);
@@ -113,20 +115,20 @@ s_rack_realpower_nominal (
 
     zmsg_t *data = zmsg_popmsg (msg);
     while (data) {
-        bios_proto_t *bmsg = bios_proto_decode (&data);
+        fty_proto_t *bmsg = fty_proto_decode (&data);
         if (!bmsg) {
-            log_warning ("decoding bios_proto_t failed");
+            log_warning ("decoding fty_proto_t failed");
             continue;
         }
 
-        if (!streq (bios_proto_type (bmsg), "realpower.nominal")) {
-            bios_proto_destroy (&bmsg);
+        if (!streq (fty_proto_type (bmsg), "realpower.nominal")) {
+            fty_proto_destroy (&bmsg);
             data = zmsg_popmsg (msg);
             continue;
         }
         else {
-            ret = std::stod (bios_proto_value (bmsg));
-            bios_proto_destroy (&bmsg);
+            ret = std::stod (fty_proto_value (bmsg));
+            fty_proto_destroy (&bmsg);
             break;
         }
     }


### PR DESCRIPTION
SUB-PROBLEM: Need to rename alert_list, asset_GET

SOLUTION: Rename it

Does not include rename of
    - systemctl rappers/services/timers etc...
    - configuration/state files etc...

`autoreconf -fiv && ./configure && make` works

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>