### PR TITLE
Problem: New daemons use new config file location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -431,6 +431,10 @@ obs_SCRIPTS	=  obs/preinstallimage-bios.sh
 
 EXTRA_DIST	+= $(obs_SCRIPTS)
 
+ipc_meta_setupdir = $(datadir)/@PACKAGE@/setup/
+ipc_meta_setup_SCRIPTS = $(top_srcdir)/setup/*.sh
+EXTRA_DIST += $(ipc_meta_setup_SCRIPTS)
+
 # SystemD integrations files; if not enabled - variables remain empty
 SYSTEMD_UNITS_LOWLEVEL =
 SYSTEMD_UNITS_EXTRA =
@@ -475,7 +479,8 @@ SYSTEMD_UNITS_LOWLEVEL += \
                         bios-reset-button.service \
                         ifplug-dhcp-autoconf.service \
                         bios-ssh-last-resort.service \
-                        bios-networking.service
+                        bios-networking.service \
+						ipc-meta-setup.service
 
 # These are verbatim (not templated) additional units that wrap third-party
 # service instances for us. TODO: should tntnet@.service move here?

--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2017 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    20-fty-compat.sh
+#  \brief   Create compat symlinks
+#  \author  Michal Vyskocil <MichalVyskocil@Eaton.com>
+#
+
+# Move file to new location and link it back
+mvln () {
+    OLD="${1}"
+    NEW="${2}"
+
+    OLD_DIR=$(dirname "${OLD}")
+    NEW_DIR=$(dirname "${NEW_}")
+
+    mkdir -p "${OLD_DIR}"
+    mkdir -p "${NEW_DIR}"
+
+    if [[ -e "${OLD}" ]]; then
+        mv "${OLD}" "${NEW}"
+        ln -sf "${NEW}" "${OLD}"
+    fi
+}
+
+mvln /etc/agent-smtp/bios-agent-smtp.cfg /etc/fty-email/fty-email.cfg
+chmod www-data: /etc/fty-email/fty-email.cfg
+mvln /etc/bios-agent-ms/bios-agent-ms.cfg /etc/fty-metric-store/fty-metric-store.cfg
+chmod www-data: /etc/fty-metric-store/fty-metric-store.cfg
+mvln /etc/agent-nut/bios-agent-nut.cfg /etc/fty-nut/fty-nut.cfg
+chmod www-data: /etc/fty-nut/fty-nut.cfg
+mvln /etc/default/bios.cfg /etc/default/fty.cfg
+chmod www-data: /etc/default/fty.cfg

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2014-2017 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    ipc-meta-setup.sh
+#  \brief   Script to manage modular initial self-configuration of an IPC
+#  \author  Michal Vyskocil <MichalVyskocil@Eaton.com>
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#  \author  Tomas Halman <TomasHalman@Eaton.com>
+#
+
+LC_ALL=C
+LANG=C
+TZ=UTC
+export LC_ALL LANG TZ
+
+BASEDIR="$(dirname $(readlink -f ${0}))"
+SETUPDIR=/var/lib/fty/ipc-meta-setup/
+
+die () {
+    echo "FATAL: " "${@}" >&2
+    exit 1
+}
+
+[ -n "${BASEDIR}" ] && [ -d "${BASEDIR}" ] || die "BASEDIR '${BASEDIR}' is not available"
+
+mkdir -p "${SETUPDIR}"
+
+ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
+
+    SCRIPT_NAME="$(basename "${SCRIPT}")"
+    if [ -f "${SETUPDIR}/${SCRIPT_NAME}.done" ]; then
+        echo "SKIP: ${SCRIPT_NAME} has already succeeded before"
+    else
+        echo "APPLY: running ${SCRIPT_NAME}..."
+        ./${SCRIPT} || die "${SCRIPT}"
+        touch "${SETUPDIR}/${SCRIPT_NAME}.done"
+    fi
+
+done

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description = Initial IPC setup on target system
+DefaultDependencies=no
+After = local-fs.target
+Before = bios.target bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service mysql.service mariadb.service saslauthd.service
+Requires = bios.target bios.service
+
+[Service]
+Type = oneshot
+User = root
+ExecStart = /usr/share/bios/scripts/setup/ipc-meta-setup.sh
+RemainAfterExit = yes
+PrivateTmp = yes
+
+[Install]
+RequiredBy=network.target systemd-tmpfiles-setup.service


### PR DESCRIPTION
Solution: add a script which will move and link back the file, so system
will just works in all cases

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>