### PR TITLE
PROBLEM: No backward compatibility

### DIFF
--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -830,7 +830,7 @@ rm -rf /var/log/mysql
 find /var/log -group bios-logread -exec chmod go-w '{}' \; || true
 find /var/log -group bios-logread -exec chmod g+r '{}' \; || true
 
-#42ity renaming
+# 42ity renaming
 ln -sf /etc/default/bios /etc/default/fty
 ln -sf /etc/default/bios /etc/default/fty.cfg
 ln -sf /etc/bios /etc/fty
@@ -840,7 +840,17 @@ ln -sf /usr/share/bios /usr/share/fty
 ln -sf /usr/share/bios/etc/default/bios /usr/share/fty/etc/default/fty
 ln -sf /usr/libexec/bios /usr/libexec/fty
 ln -sf /var/lib/bios /var/lib/fty
-
+## Backward compatibility for new (renamed) paths 
+ln -sf /var/lib/bios/bios-agent-cm      /var/lib/fty/fty-metric-compute
+ln -sf /var/lib/bios/agent-alerts-list  /var/lib/fty/fty-alert-list
+ln -sf /var/lib/bios/agent-autoconfig   /var/lib/fty/fty-autoconfig
+ln -sf /var/lib/bios/agent-outage       /var/lib/fty/fty-outage
+ln -sf /var/lib/bios/agent-smtp         /var/lib/fty/fty-email
+ln -sf /var/lib/bios/alert_agent        /var/lib/fty/fty-alert-engine
+ln -sf /var/lib/bios/bios-agent-rt      /var/lib/fty/fty-metric-cache
+ln -sf /var/lib/bios/composite-metrics  /var/lib/fty/fty-metric-composite
+ln -sf /var/lib/bios/nut                /var/lib/fty/fty-nut
+ln -sf /var/lib/bios/uptime             /var/lib/fty/fty-kpi-power-uptime
 
 sync
 echo "INFO: successfully reached the end of script: $0 $@"


### PR DESCRIPTION
When path is renamed there is no backward compatibility in case of
upgrade of old system

SOLUTION: Add specific dir links

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>