### PR TITLE
Problem: sshd does not start in container

### DIFF
--- a/systemd/bios-ssh-last-resort.service.in
+++ b/systemd/bios-ssh-last-resort.service.in
@@ -5,6 +5,8 @@ After=auditd.service network.service
 [Service]
 EnvironmentFile=-/etc/default/ssh
 ExecStartPre=/usr/bin/ssh-keygen -A
+ExecStartPre=/bin/mkdir -p /var/run/sshd
+ExecStartPre=/bin/chmod 0755 /var/run/sshd
 ExecStart=/usr/sbin/sshd -D $SSHD_OPTS -p 4222
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
Solution: create missing /var/run/sshd in ExecStart

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>