### PR TITLE
Problem: Systemd services try to run nonexisting executables.

### DIFF
--- a/systemd/bios-agent-autoconfig.service.in
+++ b/systemd/bios-agent-autoconfig.service.in
@@ -12,7 +12,7 @@ EnvironmentFile=-/usr/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-/etc/default/bios
 EnvironmentFile=-/etc/default/bios__%n.conf
 EnvironmentFile=-/etc/default/bios-db-rw
-ExecStart=@libexecdir@/@PACKAGE@/agent-autoconfig
+ExecStart=@libexecdir@/@PACKAGE@/fty-autoconfig
 Restart=always
 # Workaround for BIOS-1807 :
 TimeoutStopSec=5s

--- a/systemd/bios-agent-inventory.service.in
+++ b/systemd/bios-agent-inventory.service.in
@@ -12,7 +12,7 @@ EnvironmentFile=-/usr/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-/etc/default/bios
 EnvironmentFile=-/etc/default/bios__%n.conf
 EnvironmentFile=-/etc/default/bios-db-rw
-ExecStart=@libexecdir@/@PACKAGE@/agent-inventory
+ExecStart=@libexecdir@/@PACKAGE@/fty-inventory
 Restart=always
 
 [Install]


### PR DESCRIPTION
Solution: Fix the naming.

Signed-off-by: Jana Rapava <janarapava@eaton.com>