### PR TITLE
Problem: systemctl wrapper does not work

### DIFF
--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -35,10 +35,10 @@ mvln () {
     mkdir -p "${OLD_DIR}"
     mkdir -p "${NEW_DIR}"
 
-    if [[ -e "${OLD}" ]]; then
+    if [[ -f "${OLD}" ]]; then
         mv "${OLD}" "${NEW}"
-        ln -sf "${NEW}" "${OLD}"
     fi
+    ln -sf "${NEW}" "${OLD}"
 }
 
 mvln /etc/agent-smtp/bios-agent-smtp.cfg /etc/fty-email/fty-email.cfg

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -88,9 +88,7 @@ SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   
                                 fty-nut-configuator fty-metric-compute          \
                                 fty-metric-cache"
 
-FTY="$(find /usr/lib/systemd/system /lib/systemd/system -name 'fty*' | basename | sed -E -e 's/.(service|timer|target|path|mount|device)//')"
-
-SYSTEMCTL_UNITS_COMMON="$SYSTEMCTL_UNITS_COMMON_EXTERNAL $SYSTEMCTL_UNITS_COMMON_INTERNAL $FTY"
+SYSTEMCTL_UNITS_COMMON="$SYSTEMCTL_UNITS_COMMON_EXTERNAL $SYSTEMCTL_UNITS_COMMON_INTERNAL"
 
 # For regexp matching of multi-instance services (a pipe-separated list)
 SYSTEMCTL_UNITS_REGEX_EXTERNAL_LIST='nut-driver'


### PR DESCRIPTION
Solution: remove code handling FTY variable

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>