### PR TITLE
Problem: bios-networking: bad operator for string comparsion

### DIFF
--- a/tools/bios-networking
+++ b/tools/bios-networking
@@ -32,7 +32,7 @@ sleep 3
 
 # restart all network interfaces except lo and kill dhcp client too
 for IFACE in `ls -1 /sys/class/net/`; do
-    [ "${IFACE}" -eq "lo" ] && continue
+    [ "${IFACE}" = "lo" ] && continue
 
     (
     ifdown --force $IFACE ;\


### PR DESCRIPTION
Solution: use =

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>