### PR TITLE
Problem: we want to use TH1-TH4 in port names still

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ database/mysql/test_averages_relative.sql
 
 *.git
 tmp
+setup/20-th-names.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -367,7 +367,7 @@ EXTRA_DIST	+= $(obs_SCRIPTS)
 ipc_meta_setupdir = $(datadir)/@PACKAGE@/setup/
 ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/20-fty-compat.sh \
-	$(top_srcdir)/setup/20-th-names.sh
+	$(top_builddir)/setup/20-th-names.sh
 
 EXTRA_DIST += \
 	$(top_srcdir)/setup/20-fty-compat.sh \

--- a/Makefile.am
+++ b/Makefile.am
@@ -365,8 +365,13 @@ obs_SCRIPTS	=  obs/preinstallimage-bios.sh
 EXTRA_DIST	+= $(obs_SCRIPTS)
 
 ipc_meta_setupdir = $(datadir)/@PACKAGE@/setup/
-ipc_meta_setup_SCRIPTS = $(top_srcdir)/setup/*.sh
-EXTRA_DIST += $(ipc_meta_setup_SCRIPTS)
+ipc_meta_setup_SCRIPTS = \
+	$(top_srcdir)/setup/20-fty-compat.sh \
+	$(top_srcdir)/setup/20-th-names.sh
+
+EXTRA_DIST += \
+	$(top_srcdir)/setup/20-fty-compat.sh \
+	$(top_srcdir)/setup/20-th-names.sh.in
 
 # SystemD integrations files; if not enabled - variables remain empty
 SYSTEMD_UNITS_LOWLEVEL =

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -40,4 +40,8 @@ exampleprofile_DATA     = \
 			profile.d/bios_path.sh \
 			profile.d/lang.sh
 
-EXTRA_DIST += $(examplecfgsudo_DATA) $(examplecfgpam_DATA) $(examplecfgsec_DATA) $(examplecfgupdate_DATA) $(examplecfgrsyslogd_DATA) $(exampleprofile_DATA)
+exampleudevrulesdir = $(datarootdir)/@PACKAGE@/examples/config/rules.d
+exampleudevrules_DATA = \
+			rules.d/90-ipc-persistent-th.rules
+
+EXTRA_DIST += $(examplecfgsudo_DATA) $(examplecfgpam_DATA) $(examplecfgsec_DATA) $(examplecfgupdate_DATA) $(examplecfgrsyslogd_DATA) $(exampleprofile_DATA) $(exampleudevrules_DATA)

--- a/docs/examples/rules.d/90-ipc-persistent-th.rules
+++ b/docs/examples/rules.d/90-ipc-persistent-th.rules
@@ -1,0 +1,7 @@
+# Configure stable temperature/humidity port names on IPC
+# software will understand TH1 and $port-number
+
+SUBSYSTEM=="tty", ENV{DEVNAME}=="/dev/ttyS9", SYMLINK+="ttySTH1"
+SUBSYSTEM=="tty", ENV{DEVNAME}=="/dev/ttyS10", SYMLINK+="ttySTH2"
+SUBSYSTEM=="tty", ENV{DEVNAME}=="/dev/ttyS11", SYMLINK+="ttySTH3"
+SUBSYSTEM=="tty", ENV{DEVNAME}=="/dev/ttyS12", SYMLINK+="ttySTH4"

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -181,6 +181,9 @@ cp /usr/share/bios/examples/config/rsyslog.d/08-ipc-remote.conf /etc/rsyslog.d/
 chown root:bios-admin /etc/rsyslog.d/08-ipc-remote.conf
 chmod 0660 /etc/rsyslog.d/08-ipc-remote.conf
 
+# persistent TH naming
+cp /usr/share/bios/examples/config/rules.d/90-ipc-persistent-th.rules /lib/udev/rules.d/
+
 ## Removable media mounting point for bios-admin group
 mkdir -p /mnt/USB
 chown root:bios-admin /mnt/USB

--- a/setup/20-th-names.sh.in
+++ b/setup/20-th-names.sh.in
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2017 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    20-th-names.sh
+#  \brief   Change udev rules for HW revision 00
+#  \author  Michal Vyskocil <MichalVyskocil@Eaton.com>
+#
+
+# There were two HW revisions to consider
+# REVISION 00 with TH1-TH4 as /dev/ttyS13 - /dev/ttyS16
+# others with TH1-TH4 as /dev/ttyS9 - /dev/ttyS12
+# Installed udev rules belongs to newest revisions, so
+# 
+
+# copy&paste from tntnet-ExecStartPre.sh.in
+JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
+get_a_string_arg() { "$JSONSH" -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V") | sed 's,^"\(.*\)",\1,' ; }
+J="/etc/release-details.json"
+R=`get_a_string_arg hardware-spec-revision < $J`
+
+# we don't need to change rules for revisions != 0
+[ $R = "00" ] || exit 0
+
+# 1. change udev rules
+sed -i -e 's/ttyS9/ttyS13/g;s/ttyS10/ttyS14/g;s/ttyS11/ttyS15/g;s/ttyS12/ttyS16/g' \
+    /lib/udev/rules.d/90-ipc-persistent-th.rules
+
+# 2. force udev to load and apply them
+udevadm control --reload-rules
+udevadm trigger --subsystem-match=tty

--- a/setup/20-th-names.sh.in
+++ b/setup/20-th-names.sh.in
@@ -34,10 +34,10 @@
 JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
 get_a_string_arg() { "$JSONSH" -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V") | sed 's,^"\(.*\)",\1,' ; }
 J="/etc/release-details.json"
-R=`get_a_string_arg hardware-spec-revision < $J`
+R="$(get_a_string_arg hardware-spec-revision < $J)"
 
 # we don't need to change rules for revisions != 0
-[ $R = "00" ] || exit 0
+[ "$R" = "00" ] || exit 0
 
 # 1. change udev rules
 sed -i -e 's/ttyS9/ttyS13/g;s/ttyS10/ttyS14/g;s/ttyS11/ttyS15/g;s/ttyS12/ttyS16/g' \


### PR DESCRIPTION
Solution: create compat symlinks to real tty devices + fix compatiblity
with HW rev 00

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>