### PR TITLE
Problem: Scrip ipc-meta-setup.sh is missing in package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -368,11 +368,13 @@ EXTRA_DIST	+= $(obs_SCRIPTS)
 ipc_meta_setupdir = $(datadir)/@PACKAGE@/setup/
 ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/20-fty-compat.sh \
-	$(top_builddir)/setup/20-th-names.sh
+	$(top_builddir)/setup/20-th-names.sh \
+	$(top_srcdir)/setup/ipc-meta-setup.sh
 
 EXTRA_DIST += \
 	$(top_srcdir)/setup/20-fty-compat.sh \
-	$(top_srcdir)/setup/20-th-names.sh.in
+	$(top_srcdir)/setup/20-th-names.sh.in \
+	$(top_srcdir)/setup/ipc-meta-setup.sh
 
 # SystemD integrations files; if not enabled - variables remain empty
 SYSTEMD_UNITS_LOWLEVEL =


### PR DESCRIPTION
Solution: Add it to Makefile.am to be installed

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>