### PR TITLE
Problem: systemctl list-ipm-units "--not-active" or "--failed" glosses over units that are "activating" forever

### DIFF
--- a/tools/systemctl
+++ b/tools/systemctl
@@ -1,7 +1,7 @@
 #!/bin/bash
 # WARNING: bash syntax and capabilities are used intensively in code below!
 #
-# Copyright (C) 2015-2016 Eaton
+# Copyright (C) 2015-2017 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -236,15 +236,15 @@ Usage: ${SCRIPT_BASENAME} list-ipm-units [modifiers] [unitnames]
       --ipm-installed|--internal  List units developed as part of IPM
       --ipm-deps|--external       List units installed as dependencies for IPM
       --active                    List units with state "active" defined as:
-        if "ActiveState" is "failed" or "inactive", or if "SubState" is
-        "failed" or "dead" - skip this unit; else if "ActiveState" is
+        if "ActiveState" is "failed", "inactive", "activating", or "SubState"
+        is "failed" or "dead" - skip this unit; else if "ActiveState" is
         "active" or if "SubState" is "running" or "waiting" - show this unit;
         otherwise skip it
       --inactive|--not-active     List units with state "inactive" defined as:
         if "ActiveState" is "active" or if "SubState" is "running" or "waiting"
-        then skip this unit; else if "ActiveState" is "failed" or "inactive",
-        or if "SubState" is "failed" or "dead" or "exited" - show his unit;
-        otherwise skip it
+        then skip this unit; else if "ActiveState" is "failed", "inactive", or
+        "activating", or if "SubState" is "failed" or "dead" or "exited" - show
+        this unit; otherwise skip it
       --enabled                   List units with state "enabled" defined as:
         if "LoadState" is "not-loaded" or if "UnitFileState" is "disabled"
         then skip this unit; else if "LoadState" is "loaded" or "UnitFileState"
@@ -254,6 +254,8 @@ Usage: ${SCRIPT_BASENAME} list-ipm-units [modifiers] [unitnames]
         "static" or empty - skip this unit; otherwise show it
       --failed or --not-failed    List units that are in "failed" state vs.
                                   those that are running (or not) as expected
+                                  Note that "activating" is "failed" for us
+                                  (e.g. broken DB can be activating for days)
       --missing                   ONLY list unitnames that are in the filter
                                   but files are not installed in this system
       --init-script|--not-init-script ONLY list unit names that are implemented
@@ -798,7 +800,7 @@ $U"
                     case "$LIST_STATES" in
                         *STATE:ACTIVE*)
                             case "$I" in
-                                *[AS]:failed*|*A:inactive*|*S:dead*) SHOW2=no ;;
+                                *[AS]:failed*|*A:inactive*|*A:activating*|*S:dead*) SHOW2=no ;;
                                 *A:active*|*S:running*|*S:waiting*) SHOW2=yes ;;
                                 *S:exited*) SHOW2=no ;;
                                 *) SHOW2=no ;;
@@ -807,7 +809,7 @@ $U"
                         *STATE:INACTIVE*)
                             case "$I" in
                                 *A:active*|*S:running*|*S:waiting*) SHOW2=no ;;
-                                *[AS]:failed*|*A:inactive*|*S:dead*|*S:exited*) SHOW2=yes ;;
+                                *[AS]:failed*|*A:inactive*|*A:activating*|*S:dead*|*S:exited*) SHOW2=yes ;;
                                 *) SHOW2=no ;;
                             esac
                             ;;
@@ -816,13 +818,13 @@ $U"
                     case "$LIST_STATES" in
                         *STATE:FAILED*)
                             case "$I" in
-                                *[AS]:failed*|*:active*:dead*|*:enabled*:dead*) SHOW3=yes ;;
+                                *[AS]:failed*|*:active*:dead*|*A:activating*|*:enabled*:dead*) SHOW3=yes ;;
                                 *) SHOW3=no ;;
                             esac
                             ;;
                         *STATE:NOTFAILED*)
                             case "$I" in
-                                *[AS]:failed*|*:active*:dead*|*:enabled*:dead*) SHOW3=no ;;
+                                *[AS]:failed*|*:active*:dead*|*A:activating*|*:enabled*:dead*) SHOW3=no ;;
                                 *) SHOW3=yes ;;
                             esac
                             ;;


### PR DESCRIPTION
Solution: consider the "activating" units as failed (e.g. mysql or nut-driver instances that are trying to start up for long enough to get caught in this state).

````
root@validation-rc1:~# /tmp/systemctl  list-ipm-units --failed > /tmp/f2 2>&1
root@validation-rc1:~# systemctl  list-ipm-units --failed > /tmp/f1 2>&1

diff -bu /tmp/froot@validation-rc1:~# diff -bu /tmp/f?
--- /tmp/f1     2017-03-09 12:30:06.830574826 +0000
+++ /tmp/f2     2017-03-09 12:29:58.075576045 +0000
@@ -8,6 +8,23 @@
 fty-metric-store-cleaner.service
 fty-metric-store.service
 fty-metric-tpower.service
+mysql.service
+nut-driver@5PX1500-01.service
+nut-driver@9PX-BiosU1.service
+nut-driver@9PX-BiosU4.service
+nut-driver@BladeUPS.service
+nut-driver@ROZ.UPS14.service
+nut-driver@ROZ.UPS33.service
+nut-driver@ROZ.UPS36.service
+nut-driver@ROZ.ePDU13.service
+nut-driver@ROZ.ePDU14.service
+nut-driver@Room.2.15.a.Row1.Rack02.epdu01.service
+nut-driver@Room.2.15.a.Row1.Rack02.epdu02.service
+nut-driver@Room.2.15.b.Row1.Rack01.epdu01.service
+nut-driver@Room.2.15.b.Row1.Rack01.epdu02.service
+nut-driver@Room.2.15.b.Row1.Ups01.service
+nut-driver@ups93pm01.service
+nut-driver@ups93pm02.service
 nut-monitor.service
 nut-server.service
 tntnet@bios.service


root@validation-rc1:~# systemctl status nut-driver@ROZ.UPS14.service
* nut-driver@ROZ.UPS14.service - Network UPS Tools - device driver for ROZ.UPS14
   Loaded: loaded (/lib/systemd/system/nut-driver@.service; enabled)
   Active: activating (auto-restart) (Result: exit-code) since Thu 2017-03-09 12:30:05 UTC; 17s ago
  Process: 12550 ExecStart=/sbin/upsdrvctl start %i (code=exited, status=1/FAILURE)

Mar 09 12:30:05 validation-rc1 systemd[1]: Failed to start Network UPS Tools - device driver for ROZ.UPS14.
Mar 09 12:30:05 validation-rc1 systemd[1]: Unit nut-driver@ROZ.UPS14.service entered failed state.


root@validation-rc1:~# systemctl status mysql
* mysql.service - MySQL server
   Loaded: loaded (/usr/lib/systemd/system/mysql.service; enabled)
   Active: activating (start) since Thu 2017-03-09 12:33:18 UTC; 58s ago
  Process: 13639 ExecStartPre=/bin/dash -c if [ -d /var/lib/mysql ] ; then /bin/chown -R mysql:mysql /var/lib/mysql ; fi (code=exited, status=0/SUCCESS)
  Control: 13643 (rcmysql)
   CGroup: /system.slice/mysql.service
           |-13643 /bin/bash /usr/lib/mysql/rcmysql start
           `-13854 sleep 0.5

Mar 09 12:34:11 validation-rc1 snoopy[13845]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:12 validation-rc1 snoopy[13846]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:12 validation-rc1 snoopy[13847]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:13 validation-rc1 snoopy[13848]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:13 validation-rc1 snoopy[13849]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:14 validation-rc1 snoopy[13850]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:14 validation-rc1 snoopy[13851]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:15 validation-rc1 snoopy[13852]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:15 validation-rc1 snoopy[13853]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
Mar 09 12:34:16 validation-rc1 snoopy[13854]: [uid:0 sid:13643 tty:(none) cwd:/usr filename:/bin/sleep]: sleep 0.5
````

Now we'll know better what went bad in the box.
