### PR TITLE
Problem: we want Device UUID available in release-details.json (for fty-info)

### DIFF
--- a/obs/fty-core.dsc
+++ b/obs/fty-core.dsc
@@ -5,6 +5,6 @@ Binary: fty-core
 Architecture: any all
 Maintainer: Michal Hrusecky <MichalHrusecky@eaton.com>
 Standards-Version: 3.9.4
-Build-Depends: bison, debhelper (>= 8), flex, linuxdoc-tools, lynx | lynx-cur, pkg-config, automake, autoconf, libtool, asciidoc, docbook-xsl-ns, docbook-xsl, docbook-xml, libxml2-utils, xsltproc
+Build-Depends: bison, debhelper (>= 8), flex, linuxdoc-tools, lynx | lynx-cur, pkg-config, automake, autoconf, libtool, asciidoc, docbook-xsl-ns, docbook-xsl, docbook-xml, libxml2-utils, xsltproc, uuid, libossp-uuid16, libossp-uuid-dev
 Package-List:
  fty-core deb net optional arch=any


### PR DESCRIPTION
Solution: add the uuid program to package requirements, and support to generate the UUID from HWD details when updating the data files