### PR TITLE
Problem: hardware-uuid label is too retrictive to hardware

### DIFF
--- a/tools/generate-release-details.sh
+++ b/tools/generate-release-details.sh
@@ -232,7 +232,7 @@ cat <<EOF > ${ALTROOT}/etc/release-details.json
         "hardware-catalog-number":      "$HWD_CATALOG_NB",
         "hardware-spec-revision":       "$HWD_REV",
         "hardware-serial-number":       "$HWD_SERIAL_NB"
-        "hardware-uuid":        "$UUID_VALUE"
+        "uuid":        "$UUID_VALUE"
 } }
 EOF
 if [ $? = 0 ] ; then


### PR DESCRIPTION
Solution : rename "hardware-uuid" to "uuid"
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>