### PR TITLE
Revert "Problem: hardware-uuid label is too retrictive to hardware"

### DIFF
--- a/tools/generate-release-details.sh
+++ b/tools/generate-release-details.sh
@@ -232,7 +232,7 @@ cat <<EOF > ${ALTROOT}/etc/release-details.json
         "hardware-catalog-number":      "$HWD_CATALOG_NB",
         "hardware-spec-revision":       "$HWD_REV",
         "hardware-serial-number":       "$HWD_SERIAL_NB"
-        "uuid":        "$UUID_VALUE"
+        "hardware-uuid":        "$UUID_VALUE"
 } }
 EOF
 if [ $? = 0 ] ; then


### PR DESCRIPTION
Reverts 42ity/fty-core#56

As detailed in my comment to the original PR #56, this particular string identifies the hardware unit the best we can, for a certain definition of what "hardware" means at all (either way, a unique instance of the 42ity environment). A generic "uuid" will lose meaning very quickly, as we begin to identify more and more of other meaningful aspects of the system, and will just be ambiguous.