### PR TITLE
Revert "Revert "Problem: hardware-uuid label is too retrictive to hardware""

### DIFF
--- a/tools/generate-release-details.sh
+++ b/tools/generate-release-details.sh
@@ -233,7 +233,7 @@ cat <<EOF > ${ALTROOT}/etc/release-details.json
         "hardware-catalog-number":      "$HWD_CATALOG_NB",
         "hardware-spec-revision":       "$HWD_REV",
         "hardware-serial-number":       "$HWD_SERIAL_NB"
-        "hardware-uuid":        "$UUID_VALUE"
+        "uuid":        "$UUID_VALUE"
 } }
 EOF
 if [ $? = 0 ] ; then


### PR DESCRIPTION
Reverts #57 to restore #56

While I personally don't quite agree with this choice of naming, for the reasons I posted in comments to those earlier PRs, the CTC tribe hath spoken, and they choose how projects would interact.

CCing @aquette @jana-rapava @geraldguillaume @thalman to ultimately take into account the chosen `"uuid"` instead of `"hardware-uuid"` key name in the `release-details.json` file and `sysinfo` REST API and the data for `fty-info` and other progs and scripts that interact with this.