### PR TITLE
Problem: symlink for fty-sensor-env data created incorrectly

### DIFF
--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -851,7 +851,9 @@ ln -srf /var/lib/bios/agent-smtp         /var/lib/fty/fty-email
 ln -srf /var/lib/bios/alert_agent        /var/lib/fty/fty-alert-engine
 ln -srf /var/lib/bios/bios-agent-rt      /var/lib/fty/fty-metric-cache
 ln -srf /var/lib/bios/composite-metrics  /var/lib/fty/fty-metric-composite
-ln -srf /var/lib/bios/composite-metrics  /var/lib/fty/fty-sensor-env
+# The /var/lib/fty/fty-sensor-env should now be created via tmpfiles
+# But a legacy system may have an agent file of its own...
+ln -srf /var/lib/bios/composite-metrics/agent_th  /var/lib/fty/fty-sensor-env/agent_th
 ln -srf /var/lib/bios/nut                /var/lib/fty/fty-nut
 ln -srf /var/lib/bios/uptime             /var/lib/fty/fty-kpi-power-uptime
 


### PR DESCRIPTION
Context: Dir `/var/lib/fty/fty-sensor-env/` is pre-created by packaging now, so the symlink made later becomes
`/var/lib/fty/fty-sensor-env/composite-metrics -> ../../bios/composite-metrics` which is not what we need (we need an accessible `/var/lib/fty/fty-sensor-env/agent_th` file in the end).

Solution: in preinstallimage-bios.sh, create sensor-env symlink just for a legacy file location, new dir is made by packaging