### PR TITLE
Problem: prepackaged symlinks for legacy BIOS support make a mess

### DIFF
--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -835,38 +835,11 @@ rm -rf /var/log/mysql
 find /var/log -group bios-logread -exec chmod go-w '{}' \; || true
 find /var/log -group bios-logread -exec chmod g+r '{}' \; || true
 
-# 42ity renaming
-ln -srf /etc/default/bios /etc/default/fty
-ln -srf /etc/default/bios.cfg /etc/default/fty.cfg
-ln -srf /etc/bios /etc/fty
-ln -srf /etc/pam.d/bios /etc/pam.d/fty
-ln -srf /etc/tntnet/bios.d /etc/tntnet/fty.d
-ln -srf /usr/share/bios /usr/share/fty
-ln -srf /usr/share/bios/etc/default/bios /usr/share/fty/etc/default/fty
-ln -srf /usr/libexec/bios /usr/libexec/fty
-ln -srf /var/lib/bios /var/lib/fty
-## Backward compatibility for new (renamed) paths
-ln -srf /var/lib/bios/bios-agent-cm      /var/lib/fty/fty-metric-compute
-ln -srf /var/lib/bios/agent-alerts-list  /var/lib/fty/fty-alert-list
-ln -srf /var/lib/bios/agent-outage       /var/lib/fty/fty-outage
-ln -srf /var/lib/bios/agent-smtp         /var/lib/fty/fty-email
-ln -srf /var/lib/bios/alert_agent        /var/lib/fty/fty-alert-engine
-ln -srf /var/lib/bios/bios-agent-rt      /var/lib/fty/fty-metric-cache
-ln -srf /var/lib/bios/composite-metrics  /var/lib/fty/fty-metric-composite
-# The /var/lib/fty/fty-sensor-env should now be created via tmpfiles
-# But a legacy system may have an agent file of its own...
-ln -srf /var/lib/bios/composite-metrics/agent_th  /var/lib/fty/fty-sensor-env/agent_th
-ln -srf /var/lib/bios/nut                /var/lib/fty/fty-nut
-ln -srf /var/lib/bios/nut                /var/lib/fty/nut
-ln -srf /var/lib/bios/uptime             /var/lib/fty/fty-kpi-power-uptime
-
-# make a state directory for fty agent
-mkftydir () {
-    mkdir -p "${1}" && chown bios:root "${1}" && chmod 0755 "${1}"
-}
-
-# Stop using tmpfiles.d et all - this repo is supposed to be system integration stuff
-mkftydir /var/lib/fty/fty-autoconfig
+# Note: unlike earlier revisions, this script no longer precreates
+# legacy paths intended for compatibility with BIOS (MVP release).
+# The logic to migrate such paths in existing upgraded deployments
+# is now handled in setup/ipc-meta-setup.sh framework script and
+# corresponding systemd service unit before BIOS services start up.
 
 sync
 echo "INFO: successfully reached the end of script: $0 $@"

--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -29,7 +29,7 @@
 # and link it back for legacy compatibility purposes; optionally
 # set new ownership and access rights on the newly located file.
 # If OLD filesystem object is a directory, recurse with mvln() for
-# each object found inside it.
+# each object found inside it. See mvlndir() for wholesale relocation.
 # Note: This assumes manipulations with files in deployment local
 # data and config directories (not packaged) - so if some target
 # filenames exist under FTY paths, we should not overwrite them with
@@ -80,6 +80,26 @@ mvln () {
     if [[ -n "${MOD}" ]] && [[ -e "${NEW}" ]] ; then
         chmod $RECURSE_FLAG "${MOD}" "${NEW}"
     fi
+}
+
+# Simply move a whole existing OLD directory to a NEW name, if NEW does not
+# yet exist, and add a legacy symlink with the OLD name pointing to the NEW
+# location.
+mvlndir() {
+    OLD="${1-}"
+    NEW="${2-}"
+
+    [[ -d "${NEW}" ]] && return 0
+
+    if [[ ! -d "${OLD}" ]] || [[ -e "${NEW}" ]] ; then
+        return 1
+    fi
+
+    NEW_DIR=$(dirname "${NEW}") && \
+    [[ -n "${NEW_DIR}" ]] && \
+    mkdir -p "${NEW_DIR}" && \
+    mv "${OLD}" "${NEW}" && \
+    ln -srf "${NEW}" "${OLD}"
 }
 
 # Handle certain config files

--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -84,7 +84,8 @@ mvln () {
 
 # Simply move a whole existing OLD directory to a NEW name, if NEW does not
 # yet exist, and add a legacy symlink with the OLD name pointing to the NEW
-# location.
+# location. Generally it is safer (but slower) to mvln() recursively, with
+# existence checks done for each object along the way.
 mvlndir() {
     OLD="${1-}"
     NEW="${2-}"

--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -46,11 +46,11 @@ mvln () {
         return 0
     fi
 
-    OLD_DIR=$(dirname "${OLD}")
-    NEW_DIR=$(dirname "${NEW}")
+    OLD_DIR=$(dirname "${OLD}") && [[ -n "${OLD_DIR}" ]] || return
+    NEW_DIR=$(dirname "${NEW}") && [[ -n "${NEW_DIR}" ]] || return
 
-    mkdir -p "${OLD_DIR}"
-    mkdir -p "${NEW_DIR}"
+    mkdir -p "${OLD_DIR}" || return
+    mkdir -p "${NEW_DIR}" || return
 
     if [[ -d "${OLD}" ]]; then
         # Create dirs, symlink files; chmod+chown later

--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -41,7 +41,7 @@ mvln () {
     MOD="${4-}"
     RECURSE_FLAG=""
 
-    if [[ ! -s "${OLD}" ]] || [[ -L "${OLD}" ]] ; then
+    if [[ ! -e "${OLD}" ]] || [[ ! -s "${OLD}" ]] || [[ -L "${OLD}" ]] ; then
         # Nothing to relocate
         return 0
     fi

--- a/setup/20-fty-compat.sh
+++ b/setup/20-fty-compat.sh
@@ -117,4 +117,31 @@ mvln /etc/default/bios.cfg /etc/default/fty.cfg www-data: ""
 mvln /etc/default/bios /etc/default/fty www-data: ""
 
 # Dirs with same content and access rights
-mvln /var/lib/fty/nut /var/lib/fty/fty-nut
+mvlndir /var/lib/fty/nut /var/lib/fty/fty-nut
+
+# 42ity renaming
+mvln /etc/bios /etc/fty
+mvln /etc/pam.d/bios /etc/pam.d/fty
+mvln /etc/tntnet/bios.d /etc/tntnet/fty.d
+mvln /usr/libexec/bios /usr/libexec/fty
+mvln /var/lib/bios/license /var/lib/fty/license
+
+# Warning: order matters, somewhat
+mvln /usr/share/bios /usr/share/fty
+mvlndir /usr/share/bios/etc/default/bios /usr/share/fty/etc/default/fty
+
+## Backward compatibility for new (renamed) paths
+mvln /var/lib/bios/bios-agent-cm      /var/lib/fty/fty-metric-compute
+mvln /var/lib/bios/agent-alerts-list  /var/lib/fty/fty-alert-list
+mvln /var/lib/bios/agent-outage       /var/lib/fty/fty-outage
+mvln /var/lib/bios/agent-smtp         /var/lib/fty/fty-email
+mvln /var/lib/bios/alert_agent        /var/lib/fty/fty-alert-engine
+mvln /var/lib/bios/bios-agent-rt      /var/lib/fty/fty-metric-cache
+mvln /var/lib/bios/composite-metrics  /var/lib/fty/fty-metric-composite
+mvln /var/lib/bios/nut                /var/lib/fty/fty-nut
+mvln /var/lib/bios/nut                /var/lib/fty/nut
+mvln /var/lib/bios/uptime             /var/lib/fty/fty-kpi-power-uptime
+
+# The /var/lib/fty/fty-sensor-env should now be created via tmpfiles
+# But a legacy system may have an agent file of its own...
+mvln /var/lib/bios/composite-metrics/agent_th  /var/lib/fty/fty-sensor-env/agent_th


### PR DESCRIPTION
Solution: push towards generation of FTY pathnames for /var/lib/fty via tmpfiles, and IFF an old system is being updated - relocate (and rename) its data from /var/lib/bios to /var/lib/fty.