### PR TITLE
Problem: db created after startup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -422,8 +422,7 @@ SYSTEMD_UNITS_LOWLEVEL += \
                         ifplug-dhcp-autoconf.service \
                         bios-ssh-last-resort.service \
                         bios-networking.service \
-                        ipc-meta-setup.service \
-						fty-db-init.service
+                        ipc-meta-setup.service
 
 # These are verbatim (not templated) additional units that wrap third-party
 # service instances for us. TODO: should tntnet@.service move here?
@@ -446,7 +445,8 @@ SYSTEMD_UNITS += $(SYSTEMD_UNITS_TARGET_BIOS) $(SYSTEMD_UNITS_LOWLEVEL)
 #SYSTEMD_UNITS_NOTPRESET_LOWLEVEL +=
 SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS += \
                         bios-fake-th.service \
-						fty-db-upgrade.service
+						fty-db-upgrade.service \
+						fty-db-init.service
 
 SYSTEMD_UNITS_NOTPRESET += $(SYSTEMD_UNITS_NOTPRESET_LOWLEVEL) $(SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS)
 
@@ -486,7 +486,7 @@ $(SYSTEMD_SUBDIR)/42-bios-systemd.preset: Makefile
 	@mkdir -p "$(abs_top_builddir)/$(SYSTEMD_SUBDIR)" "`dirname "$@"`" || true
 	@( echo "### This is a generated file with a list of all BIOS-related services with their default state"; \
 	  for F in $(SYSTEMD_TARGETS) $(SYSTEMD_UNITS) $(SYSTEMD_TIMERS) ; do echo "enable $$F" ; done ) > $@
-	@printf "disable %s\n" fty-db-upgrade >> $@
+	@printf "disable %s\ndisable %s\ndisable mysql\n" fty-db-init fty-db-upgrade >> $@
 
 # The rules to actually "compile" the service definition files
 # is part of catch-all %.in recipe above

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -392,8 +392,10 @@ cp /usr/share/fty/examples/config/update-rc3.d/* /etc/update-rc3.d
 [ -n "$IMGTYPE" ] && \
     echo "IMGTYPE='$IMGTYPE'" > /etc/update-rc3.d/image-os-type.conf
 
-# Enable mysql
-/bin/systemctl enable mysql
+# Disable mysql and db services, will be enabled during license_POST call
+/bin/systemctl disable mysql
+/bin/systemctl disable fty-db-init
+/bin/systemctl disable fty-db-upgrade
 
 # Disable systemd-timesyncd - ntp is enough
 /bin/systemctl mask systemd-timesyncd.service


### PR DESCRIPTION
Solution: make sure all fty-db-*, mysql is DISABLED from the start

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>