### PR TITLE
Problem: DB is still created during boot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -446,8 +446,8 @@ SYSTEMD_UNITS += $(SYSTEMD_UNITS_TARGET_BIOS) $(SYSTEMD_UNITS_LOWLEVEL)
 #SYSTEMD_UNITS_NOTPRESET_LOWLEVEL +=
 SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS += \
                         bios-fake-th.service \
-						fty-db-upgrade.service \
-						fty-db-init.service
+						fty-db-init.service \
+						fty-db-firstboot.service
 
 SYSTEMD_UNITS_NOTPRESET += $(SYSTEMD_UNITS_NOTPRESET_LOWLEVEL) $(SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS)
 
@@ -489,7 +489,7 @@ $(SYSTEMD_SUBDIR)/42-bios-systemd.preset: Makefile
 	@mkdir -p "$(abs_top_builddir)/$(SYSTEMD_SUBDIR)" "`dirname "$@"`" || true
 	@( echo "### This is a generated file with a list of all BIOS-related services with their default state"; \
 	  for F in $(SYSTEMD_TARGETS) $(SYSTEMD_UNITS) $(SYSTEMD_TIMERS) ; do echo "enable $$F" ; done ) > $@
-	@for F in fty-db-init.service fty-db-upgrade.service mysql.service ; do echo "disable $$F" ; done >> $@
+	@for F in fty-db-init.service bios-db-init.service fty-db-firstboot.service mysql.service ; do echo "disable $$F" ; done >> $@
 
 # The rules to actually "compile" the service definition files
 # is part of catch-all %.in recipe above

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -395,7 +395,8 @@ cp /usr/share/fty/examples/config/update-rc3.d/* /etc/update-rc3.d
 # Disable mysql and db services, will be enabled during license_POST call
 /bin/systemctl disable mysql
 /bin/systemctl disable fty-db-init
-/bin/systemctl disable fty-db-upgrade
+/bin/systemctl disable bios-db-init
+/bin/systemctl disable fty-db-firstboot
 
 # Disable systemd-timesyncd - ntp is enough
 /bin/systemctl mask systemd-timesyncd.service

--- a/systemd/fty-db-firstboot.service.in
+++ b/systemd/fty-db-firstboot.service.in
@@ -1,10 +1,10 @@
 [Unit]
-Description=Upgrade database schema for 42ity services
+Description=First boot database schema initalization for 42ity services
 After=mysql.service
 Requires=mysql.service
 Conflicts=shutdown.target
-#do not run if database was not yet initialized
-ConditionPathExists=/var/lib/fty/sql/mysql/bios-db-rw
+#Run only if database was not initialized
+ConditionPathExists=!/var/lib/fty/sql/mysql/bios-db-rw
 
 [Service]
 # it is expected that the process has to exit before systemd starts follow-up units
@@ -21,7 +21,7 @@ EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
-ExecStart=@libexecdir@/@PACKAGE@/db-init upgrade
+ExecStart=@libexecdir@/@PACKAGE@/db-init
 
 [Install]
 WantedBy=bios.target

--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -1,15 +1,10 @@
 [Unit]
 Description=Initialize database schema for 42ity services
-# ordering of upgrade->init is weird, but makes a sense
-# 1. on a first bool fty-db-init is started when license is accepted and
-#    fty-db-upgrade is skipped due ConditionPathExists there
-# 2. on other boots fty-db-upgrade runst firs and fty-db-init is skipped due
-#    ConditionPathExists, so it's a depenency for db dependent services
-After=mysql.service fty-db-upgrade.service
+After=mysql.service
 Requires=mysql.service
 Conflicts=shutdown.target
-#do not run if database has been already initialized
-ConditionPathExists=!/var/lib/fty/sql/mysql/bios-db-rw
+#do not run if database was not yet initialized
+ConditionPathExists=/var/lib/fty/sql/mysql/bios-db-rw
 
 [Service]
 # it is expected that the process has to exit before systemd starts follow-up units

--- a/tools/start-db-services
+++ b/tools/start-db-services
@@ -29,7 +29,7 @@ if [[ -f /etc/default/bios-db-rw ]]; then
     exit 0
 fi
 
-sudo /bin/systemctl start fty-db-init || die "Starting fty-db-init failed"
+sudo /bin/systemctl start fty-db-firstboot || die "Starting fty-db-firstboot failed"
 
 sleep 2
 if [[ ! -f /etc/default/bios-db-rw ]]; then
@@ -38,7 +38,6 @@ if [[ ! -f /etc/default/bios-db-rw ]]; then
 fi
 
 sudo /bin/systemctl enable fty-db-init || die "Enabling fty-db-init failed"
-sudo /bin/systemctl enable fty-db-upgrade || die "Enabling fty-db-upgrade failed"
 sudo /bin/systemctl enable mysql || die "Enabling mysql failed"
 
 for DIR in /lib/systemd/system /usr/lib/systemd/system /run/systemd/system /etc/systemd/system/; do


### PR DESCRIPTION
Solution: ... because fty-db-init is pullet via bios-db-init Requires.
Drop fty-db-upgrade (it never made a sense as db-init script do both).
Add fty-db-firstboot, which runs only if db was not initialized and
remains disabled by default. And disable bios-db-init too.

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>