### PR TITLE
Problem: TestLicense fails

### DIFF
--- a/tools/systemctl
+++ b/tools/systemctl
@@ -80,7 +80,7 @@ SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   
                                 fty-metric-tpower bios-agent-inventory          \
                                 fty-info fty-mdns-sd fty-metric-snmp            \
                                 bios-db-init bios-fake-th bios-networking       \
-                                fty-db-init fty-db-upgrade                      \
+                                fty-db-init fty-db-firstboot                    \
                                 bios-reset-button bios-ssh-last-resort          \
                                 biostimer-compress-logs biostimer-verify-fs     \
                                 biostimer-loghost-rsyslog-netconsole fty-nut    \


### PR DESCRIPTION
Solution: add fty-db-firstboot to the wrapper

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>