### PR TITLE
Problem: DB is still started on first boot

### DIFF
--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -20,9 +20,10 @@
 #  \author Michal Vyskocil <MichalVyskocil@eaton.com>
 #  \author Jim Klimov <EvgenyKlimov@eaton.com>
 
+# we're using mask/unmask on mysql, not available in a wrapper
+SYSTEMCTL=/bin/systemctl
 ### Prefer to use our wrapper that limits impact to permitted targets
-#SYSTEMCTL=/bin/systemctl
-SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
+#SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
 
 die () {
     echo "ERROR: ${@}" >&2
@@ -34,6 +35,8 @@ if [[ -f /etc/default/bios-db-rw ]]; then
     exit 0
 fi
 
+sudo ${SYSTEMCTL} unmask mysql || die "Unmasking mysql failed"
+sudo ${SYSTEMCTL} enable mysql || die "Enabling mysql failed"
 sudo ${SYSTEMCTL} start fty-db-firstboot || die "Starting fty-db-firstboot failed"
 
 sleep 2
@@ -43,7 +46,6 @@ if [[ ! -f /etc/default/bios-db-rw ]]; then
 fi
 
 sudo ${SYSTEMCTL} enable fty-db-init || die "Enabling fty-db-init failed"
-sudo ${SYSTEMCTL} enable mysql || die "Enabling mysql failed"
 
 for DIR in /lib/systemd/system /usr/lib/systemd/system /run/systemd/system /etc/systemd/system/; do
     if [[ ! -d "${DIR}" ]]; then


### PR DESCRIPTION
Solution: mask it, so it won't be started under ANY circumstances.
start-db-service called by license acceptance will unmask and enable it.

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>