### PR TITLE
Problem: our systemctl wrapper does not allow mask/unmask

### DIFF
--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -20,10 +20,9 @@
 #  \author Michal Vyskocil <MichalVyskocil@eaton.com>
 #  \author Jim Klimov <EvgenyKlimov@eaton.com>
 
-# we're using mask/unmask on mysql, not available in a wrapper
-SYSTEMCTL=/bin/systemctl
 ### Prefer to use our wrapper that limits impact to permitted targets
-#SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
+#SYSTEMCTL=/bin/systemctl
+SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
 
 die () {
     echo "ERROR: ${@}" >&2

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -51,7 +51,7 @@ for DIR in /lib/systemd/system /usr/lib/systemd/system /run/systemd/system /etc/
         continue
     fi
 
-    egrep 'Requires.*bios-db-init.service' "${DIR}"/*.service 2>/dev/null \
+    egrep 'Requires.*(fty|bios)-db-init.service' "${DIR}"/*.service 2>/dev/null \
     | cut -d ':' -f 1 \
     | xargs -L1 basename 2>/dev/null \
     | while read SERVICE; do

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -53,7 +53,7 @@ MAINARGS="$0 $*"
 # Use syslog if "logger" is available
 LOGGER="$(which logger)" 2>/dev/null || LOGGER=""
 
-SYSTEMCTL_COMMANDS="show start stop restart reload reload-or-restart try-reload-or-restart enable disable daemon-reload status is-active list-dependencies"
+SYSTEMCTL_COMMANDS="show start stop restart reload reload-or-restart try-reload-or-restart enable disable mask unmask daemon-reload status is-active list-dependencies"
 # NOTE: We do not support "--unit=UNITNAME" because it is too much hassle here
 # NOTE: We do also support the two-token "-n NUMBER" explicitly below
 JOURNALCTL_COMMANDS="-f --follow -l -u -fl -lf -fu -uf -lu -ul -flu -ful -luf -lfu -ulf -ufl -a --all --no-pager -r --reverse -k --dmesg"


### PR DESCRIPTION
Solution: now that we have usecases for these methods, allow to use them against our units

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>