### PR TITLE
Problem: a tntnet@.service is also delivered by tntnet package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,8 +173,8 @@ systemd/ipc-meta-setup.service
 systemd/fty-db-init.service
 !systemd/fty-db-engine.service.in
 systemd/fty-db-engine.service
-!systemd/tntnet@.service.in
-systemd/tntnet@.service
+!systemd/fty-tntnet@.service.in
+systemd/fty-tntnet@.service
 
 !tools/tntnet-ExecStartPre.sh.in
 tools/tntnet-ExecStartPre.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -447,10 +447,12 @@ SYSTEMD_UNITS += $(SYSTEMD_UNITS_TARGET_BIOS) $(SYSTEMD_UNITS_LOWLEVEL)
 
 # These units have unit files installed but are not enabled nor disabled
 # by default via presets nor timers (may be enabled in OS image generation
-# script or during deployment's lifetime)
+# script or during deployment's lifetime).
+# Note: Due to conflict with "tntnet@.service" file from tntnet package,
+# we name ours differently here (and override during OS image generation).
 #SYSTEMD_UNITS_NOTPRESET_LOWLEVEL +=
 SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS += \
-                        tntnet@.service \
+                        fty-tntnet@.service \
                         bios-fake-th.service
 
 SYSTEMD_UNITS_NOTPRESET += $(SYSTEMD_UNITS_NOTPRESET_LOWLEVEL) $(SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS)

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -452,6 +452,7 @@ done
 
 # Our tntnet unit rocks, disable packaged default
 rm -f /etc/init.d/tntnet
+cp -f /lib/systemd/system/fty-tntnet@.service /lib/systemd/system/tntnet@.service
 
 # Enable REST API via tntnet
 # Note: for legacy reasons, we still maintain tntnet@bios.service (not @fty)

--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Tntnet web server instance for 42ity using @sysconfdir@/tntnet/%I.xml
+Description=Tntnet web server instance for 42ity using @sysconfdir@/tntnet/%i.xml
 After=network.target saslauthd.service malamute.service
 Requires=saslauthd.service malamute.service
 PartOf=bios.target
@@ -24,3 +24,4 @@ ExecStart=/usr/bin/tntnet -c @sysconfdir@/tntnet/%i.xml
 
 [Install]
 WantedBy=bios.target
+Alias=tntnet@%i.service

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -3,7 +3,7 @@ Description = Initial IPC setup on target system
 DefaultDependencies=no
 After = local-fs.target
 Requires = local-fs.target
-Before = bios.target bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service
+Before = bios.target bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service
 #Requires = bios.target bios.service
 
 [Service]

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -1029,7 +1029,7 @@ systemctl_list_needs() (
     if [[ -n "$SYSTEMCTL_UNITS" ]] ; then
         SYSTEMCTL_UNITS="`$SYSTEMCTL show -p Id $SYSTEMCTL_UNITS | sed 's,^.*=,,'`"
     else
-        SYSTEMCTL_UNITS="tntnet@bios.service bios.service bios.target `list_known_ipm_units | egrep -v 'tntnet@bios.service|bios.service|bios.target'`"
+        SYSTEMCTL_UNITS="tntnet@bios.service bios.service bios.target fty-license-accepted.target `list_known_ipm_units | egrep -v 'tntnet@bios.service|bios.service|bios.target'`"
     fi
     export RECURSIVE
 

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -74,6 +74,7 @@ SYSTEMCTL_UNITS_COMMON_EXTERNAL="mariadb mysql mysqld                   \
 # SYSTEMCTL_UNITS_COMMON_INTERNAL lists the services delivered by our project
 # TODO: legacy-metrics will be removed, drop it there
 SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   \
+                                fty-tntnet@bios                                 \
                                 fty-license-accepted fty-db-init fty-db-engine  \
                                 fty-kpi-power-uptime fty-alert-list fty-asset   \
                                 fty-metric-store-cleaner fty-alert-engine       \


### PR DESCRIPTION
Solution: name fty-core version differently and override during OS image generation

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>