### PR TITLE
Problem: recent changes in db-init are not clear

### DIFF
--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -200,11 +200,11 @@ EOF
 		# Code above should have ensured that BIOS_DB_RW is correct
 		echo "Database for BIOS initialization - creating BIOS_DB_RW_LEGACY symlink pointing to correct password file BIOS_DB_RW..." >&2 && \
 		rm -f "${BIOS_DB_RW_LEGACY}" && \
-		ln -s "${BIOS_DB_RW}" "${BIOS_DB_RW_LEGACY}"
-        chgrp www-data "${BIOS_DB_RW}"
-        chmod g+r "${BIOS_DB_RW}"
-        chgrp www-data "/var/lib/@PACKAGE@/sql"
-        chgrp www-data "/var/lib/@PACKAGE@/sql/mysql"
+			ln -s "${BIOS_DB_RW}" "${BIOS_DB_RW_LEGACY}"
+		# Our web-server should be able to read these credentials, at least per current implementation of license_POST
+		chgrp www-data "${BIOS_DB_RW}"
+		chmod g+r "${BIOS_DB_RW}"
+		chgrp www-data "${CREDSQL_DIR}"
 	fi
 
 	if [ -L "${BIOS_DB_RO_LEGACY}" ] && [ -s "${BIOS_DB_RO}" ] && diff -q "${BIOS_DB_RO_LEGACY}" "${BIOS_DB_RO}" ; then


### PR DESCRIPTION
db-init.in : use proper varnames for paths; fix whitespace; comment what and why we do by these www-data access rights