### PR TITLE
Problem: 10-avahi-lxc.sh not installed into OS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -370,12 +370,15 @@ obs_SCRIPTS	=  obs/preinstallimage-bios.sh
 EXTRA_DIST	+= $(obs_SCRIPTS)
 
 ipc_meta_setupdir = $(datadir)/@PACKAGE@/setup/
+# Note: use srcdir for verbatim scripts, builddir for templated .sh.in products
 ipc_meta_setup_SCRIPTS = \
+	$(top_srcdir)/setup/10-avahi-lxc.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_builddir)/setup/20-th-names.sh \
 	$(top_srcdir)/setup/ipc-meta-setup.sh
 
 EXTRA_DIST += \
+	$(top_srcdir)/setup/10-avahi-lxc.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-th-names.sh.in \
 	$(top_srcdir)/setup/ipc-meta-setup.sh


### PR DESCRIPTION
Solution: mention it in Makefile :)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>