### PR TITLE
Problem: fty-route does not list numeric data

### DIFF
--- a/tools/fty-route
+++ b/tools/fty-route
@@ -78,7 +78,11 @@ fi
 
 case "${ARGS[0]}" in
     list)
-        /sbin/route
+        if [[ "${ARGS[1]}" = "-n" ]] ; then
+            /sbin/route -n
+        else
+            /sbin/route
+        fi
         ;;
     add)
         /sbin/route "${@}" || die "Command route ${@} failed"


### PR DESCRIPTION
Solution: allow "fty-route list -n" to avoid DNS resolution delays

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>