### PR TITLE
Problem: fty-nut-configurator not manageable by wrapper

### DIFF
--- a/tools/systemctl
+++ b/tools/systemctl
@@ -87,7 +87,7 @@ SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   
                                 biostimer-loghost-rsyslog-netconsole fty-nut    \
                                 biostimer-warranty-metric ifplug-dhcp-autoconf  \
                                 ipc-meta-setup fty-sensor-env                   \
-                                fty-nut-configuator fty-metric-compute          \
+                                fty-nut-configurator fty-metric-compute         \
                                 fty-metric-cache fty-alert-flexible"
 
 SYSTEMCTL_UNITS_COMMON="$SYSTEMCTL_UNITS_COMMON_EXTERNAL $SYSTEMCTL_UNITS_COMMON_INTERNAL"


### PR DESCRIPTION
Solution: fix typo in service name

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>