### PR TITLE
Problem: HW watchdog does not start if tmpfiles failed

### DIFF
--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -7,6 +7,8 @@ PartOf=bios.target
 [Service]
 Type=simple
 Restart=always
+User=root
+Group=root
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-@prefix@/share/fty/etc/default/fty

--- a/systemd/wd_keepalive@.service
+++ b/systemd/wd_keepalive@.service
@@ -5,6 +5,9 @@ Description=watchdog keepalive daemon for device /dev/%i
 Before=watchdog.service wd_keepalive.service shutdown.target
 # No real conflict with "watchdog" unless it tries to use same devices
 Conflicts=wd_keepalive.service shutdown.target
+# Trigger startup of tmpfiles and run afterwards if possible, but do not fret if that fails
+After=systemd-tmpfiles-setup.service
+Wants=systemd-tmpfiles-setup.service
 ConditionPathExists=/dev/%i
 
 [Service]
@@ -23,8 +26,8 @@ ExecStartPre=-/bin/systemctl reset-failed wd_keepalive.service
 # "KA_PIDFILE" is hardcoded during compilation, so we must dance a bit
 ExecStart=/bin/bash -c 'echo "watchdog-device = /dev/%i" > /var/run/wd_keepalive@%i.conf && /usr/sbin/wd_identify -c /var/run/wd_keepalive@%i.conf && ( flock -x -w 5 200 && /usr/sbin/wd_keepalive -c /var/run/wd_keepalive@%i.conf $watchdog_options && mv -f /var/run/wd_keepalive.pid /var/run/wd_keepalive@%i.pid; RES=$?; flock -u 200; exit $RES; ) 200>/var/run/wd_keepalive@.flock'
 ExecStartPost=/bin/sh -c 'rm -f /var/run/wd_keepalive@.flock'
-ExecStartPost=/bin/sh -c 'ln -s /var/run/wd_keepalive@%i.pid /run/sendsigs.omit.d/wd_keepalive@%i.pid'
-ExecStopPost=/bin/sh -c 'rm -f /run/sendsigs.omit.d/wd_keepalive@%i.pid'
+ExecStartPost=/bin/sh -c 'if [ -d /run/sendsigs.omit.d ] ; then ln -s /var/run/wd_keepalive@%i.pid /run/sendsigs.omit.d/wd_keepalive@%i.pid ; else echo "WARNING: systemd-tmpfiles-setup may have failed, expected directory is missing!" >&2; fi'
+ExecStopPost=/bin/sh -c 'if [ -d /run/sendsigs.omit.d ] ; then rm -f /run/sendsigs.omit.d/wd_keepalive@%i.pid ; else echo "WARNING: systemd-tmpfiles-setup may have failed, expected directory is missing!" >&2; fi'
 
 [Install]
 WantedBy=basic.target rescue.target emergency.target

--- a/tools/loghost-rsyslog
+++ b/tools/loghost-rsyslog
@@ -39,6 +39,7 @@ CONFIGFS_ROOT="/sys/kernel/config"
 CONFIGFS_NETCONSOLE="$CONFIGFS_ROOT/netconsole"
 
 LOCKFILE="/tmp/.`basename $0`.lock"
+RESTART_RSYSLOGD="auto"
 
 usage() {
     cat <<EOF
@@ -155,13 +156,16 @@ process_action_hosts() {
     # Caller should set HOSTSFENCE to either $HOSTSFENCE_MANUAL
     # or $HOSTSFENCE_NETCONSOLE according to situation.
     case "$ACTION_HOSTS" in
-        _SKIP_) return 0 ;;
+        _SKIP_)
+            if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi
+            return 0 ;;
         tryset|forceset)
             query_loghost_name >/dev/null
             RES=$?
             case "$RES" in
                 1)  if [ "$ACTION_HOSTS" = tryset ]; then
                         echo "WARN: Will not change $RSYSLOG_LOGHOST in $HOSTSFILE because it is not managed by us" >&2
+                        if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi
                         return 1
                     else
                         echo "WARN: Forced to change $RSYSLOG_LOGHOST in $HOSTSFILE which was not managed by us" >&2
@@ -173,6 +177,7 @@ process_action_hosts() {
                     [ "$RES" != 1 ] && [ -n "$VALUE_HOSTS" ] && \
                         egrep '^[[:blank:]]*'"$VALUE_HOSTS"'[[:blank:]]+(.*[[:blank:]]+|)'"$RSYSLOG_LOGHOST"'([[:blank:]]+.*|[[:blank:]]*)$' "$HOSTSFILE" >/dev/null && \
                         echo "INFO: $RSYSLOG_LOGHOST in $HOSTSFILE is already up-to-date and managed by this script, got nothing to do" >&2 && \
+                        { if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi; true; } && \
                         return 0
                     [ "$RES" = 0 ] && [ "$HOSTSFENCE" = "$HOSTSFENCE_NETCONSOLE" ] && \
                         [ "$ACTION_HOSTS" = tryset ] && \
@@ -197,9 +202,12 @@ process_action_hosts() {
             query_loghost_name >/dev/null
             RES=$?
             case "$RES" in
-                22|53) return 0 ;; # This name is absent locally - nothing to do
+                22|53)
+                    if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi
+                    return 0 ;; # This name is absent locally - nothing to do
                 1)  if [ "$ACTION_HOSTS" = trydel ]; then
                         echo "WARN: Will not change $RSYSLOG_LOGHOST in $HOSTSFILE because it is not managed by us" >&2
+                        if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi
                         return 1
                     else
                         echo "WARN: Forced to change $RSYSLOG_LOGHOST in $HOSTSFILE which was not managed by us" >&2
@@ -212,6 +220,7 @@ process_action_hosts() {
                         if egrep '^[[:blank:]]*'"$VALUE_HOSTS"'[[:blank:]]+(.*[[:blank:]]+|)'"$RSYSLOG_LOGHOST"'([[:blank:]]+.*|[[:blank:]]*)$' "$HOSTSFILE" >/dev/null \
                         ; then : ; else \
                             echo "INFO: $RSYSLOG_LOGHOST in $HOSTSFILE has no mappings to IP address $VALUE_HOSTS, got nothing to do" >&2 && \
+                            { if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi; true; } && \
                             return 0
                         fi
                     [ "$RES" = 0 ] && [ "$HOSTSFENCE" = "$HOSTSFENCE_NETCONSOLE" ] && \
@@ -233,8 +242,11 @@ process_action_hosts() {
 
 process_action_toggle() {
     [ -n "$RESTART_RSYSLOGD" ] || RESTART_RSYSLOGD=no
+    [ "$RESTART_RSYSLOGD" != auto ] || RESTART_RSYSLOGD=no
     case "$ACTION_TOGGLE" in
-        _SKIP_) return 0;;
+        _SKIP_)
+            if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi
+            return 0;;
         enable-backup)
             [ -s "$RSYSLOG_TOGGLE_FILE_ACTIVE" ] && \
                 return 0
@@ -252,6 +264,7 @@ process_action_toggle() {
                 if [ -s "$RSYSLOG_TOGGLE_FILE_ACTIVE" ] ; then
                     fgrep "$NEWVAL" "$RSYSLOG_TOGGLE_FILE_ACTIVE" >/dev/null && \
                         echo "INFO: $RSYSLOG_TOGGLE_FILE_ACTIVE is already up-to-date and managed by this script, got nothing to do" >&2 && \
+                        { if [ "$RESTART_RSYSLOGD" = auto ]; then RESTART_RSYSLOGD=no_changes; fi; true; } && \
                         return 0
 
                     [ "$HOSTSFENCE" = "$HOSTSFENCE_NETCONSOLE" ] && \
@@ -302,6 +315,11 @@ optional_restart_rsyslogd() {
         echo "INFO: Restarting the rsyslog service for new settings to take effect" >&2
         /bin/systemctl restart rsyslog
         return $?
+    fi
+
+    if [ "$RESTART_RSYSLOGD" = no_changes ]; then
+        unset RESTART_RSYSLOGD
+        return 0
     fi
 
     # Should not get here if there were changes to enable


### PR DESCRIPTION
Solution: tmpfiles is a different big system issue; we want the HW watchdog to run - so make no hard dependency

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>