### PR TITLE
Problem: 15-dpkg-database.everytime.sh has potential to break the system

### DIFF
--- a/setup/15-dpkg-database.everytime.sh
+++ b/setup/15-dpkg-database.everytime.sh
@@ -175,3 +175,7 @@ case "$ACTION" in
         ;;
     *) die "ACTION '$ACTION' is not implemented nor supported (yet?)" ;;
 esac
+
+### Final sanity check
+[ -d "${RW_ROOT}${DPKG_DIR}" ] && [ -s "${RW_ROOT}${DPKG_STATE}" ] && [ -d "${RW_ROOT}${DPKG_INFO_DIR}" ] \
+|| die "Debian packaging metadata is not accessible as exected in the RW_ROOT, this is likely a scripting error in $0"


### PR DESCRIPTION
Solution: add a final sanity check - that we do still have the metadata in live system