### PR TITLE
systemctl : support fty-discovery and fty-sensor-gpio

### DIFF
--- a/tools/systemctl
+++ b/tools/systemctl
@@ -87,6 +87,7 @@ SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   
                                 biostimer-loghost-rsyslog-netconsole fty-nut    \
                                 biostimer-warranty-metric ifplug-dhcp-autoconf  \
                                 ipc-meta-setup fty-sensor-env fty-discovery     \
+                                fty-sensor-gpio                                 \
                                 fty-nut-configurator fty-metric-compute         \
                                 fty-metric-cache fty-alert-flexible"
 

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -86,7 +86,7 @@ SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   
                                 biostimer-compress-logs biostimer-verify-fs     \
                                 biostimer-loghost-rsyslog-netconsole fty-nut    \
                                 biostimer-warranty-metric ifplug-dhcp-autoconf  \
-                                ipc-meta-setup fty-sensor-env                   \
+                                ipc-meta-setup fty-sensor-env fty-discovery     \
                                 fty-nut-configurator fty-metric-compute         \
                                 fty-metric-cache fty-alert-flexible"
 


### PR DESCRIPTION
Update the filter of services that our wrapper allows to manipulate.