### PR TITLE
Problem: first startup of tntnet fails

### DIFF
--- a/tools/_bios-script.sh
+++ b/tools/_bios-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2016 Eaton
+# Copyright (C) 2016-2017 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,18 +19,21 @@
 #! \file   _bios-script.sh
 #  \brief  Initialize password for _bios-script user
 #  \author Michal Vyskocil <MichalVyskocil@Eaton.com>
+#  \author Jim Klimov <EvgenyKlimov@Eaton.com>
 
 PASSWD="/etc/default/_bios-script"
 random_password() {
         # Generate a random ASCII string without "confusing" characters
-        head -c 12 /dev/urandom | base64 | sed 's,[\+\=\/\ \t\n\r\%],_,g'
+        # yet strong enough for the checks (so add some varied chars)
+        head -c 12 /dev/urandom | base64 | sed -e 's,[\+\=\/\ \t\n\r\%],_,g' -e 's|^\(....\)\(...\)\(.*\)|0_9z\1@\2A,\3!|'
 }
 
-if [[ ! -f "${PASSWD}" ]]; then
-    password=$(random_password)
-    printf 'BIOS_USER="_bios-script"\nBIOS_PASSWD="%s"' "${password}" >"${PASSWD}" 
+if [[ ! -s "${PASSWD}" ]]; then
+    password="$(random_password)"
+    cat /dev/null > "${PASSWD}"
     chown root:bios-admin "${PASSWD}"
     chmod 0640 "${PASSWD}"
+    printf 'BIOS_USER="_bios-script"\nBIOS_PASSWD="%s"\n' "${password}" > "${PASSWD}"
 
     passwd _bios-script << EOF
 ${password}


### PR DESCRIPTION
Solution: strengthen password generation so it is accepted by security filters

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>