### PR TITLE
Problem: update-rc3 sorts respins wrongly

### DIFF
--- a/tools/update-rc3
+++ b/tools/update-rc3
@@ -707,14 +707,16 @@ sort_osimage_names() {
     # ASSUMPTION: we don't have over 999 rebuilds of the same baseline image ;)
     # ASSUMPTION2: all image builds have a rebuild-index suffix for the same
     # baseline, or there is one old image for a baseline without a suffix.
+    # NOTE: Over project lifetime, the rebuild numbers were separated by "dash"
+    # or by "plus" so we support both below.
     ### sort
     ### sort -n
     sed -e 's,-\([[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\)_,-\1-0_,' \
-        -e 's,-\([[:digit:]]\)_,-0\1_,' \
-        -e 's,-\([[:digit:]][[:digit:]]\)_,-0\1_,' \
+        -e 's,\([\-\+]\)\([[:digit:]]\)_,\10\2_,' \
+        -e 's,\([\-\+]\)\([[:digit:]][[:digit:]]\)_,\10\2_,' \
     | sort -n | \
-    sed -e 's,-0*\([123456789][[:digit:]]*\)_,-\1_,' \
-        -e 's,-00*_,_,'
+    sed -e 's,\([\-\+]\)0*\([123456789][[:digit:]]*\)_,\1\2_,' \
+        -e 's,\([\-\+]\)00*_,_,'
 }
 
 findnewest_osimage() (


### PR DESCRIPTION
Solution: support respin numbers separated by either "plus" or "minus" characters nowadays, so "+9" is no longer "newer" than "+51" ;)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>