### PR TITLE
Problem: new IPC LCD services not enabled on upgrade

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -361,6 +361,7 @@ ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/10-avahi-lxc.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
+	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_builddir)/setup/20-th-names.sh \
 	$(top_srcdir)/setup/ipc-meta-setup.sh
 
@@ -368,6 +369,7 @@ EXTRA_DIST += \
 	$(top_srcdir)/setup/10-avahi-lxc.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
+	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_srcdir)/setup/20-th-names.sh.in \
 	$(top_srcdir)/setup/ipc-meta-setup.sh
 

--- a/setup/20-ipc-lcd-services.sh
+++ b/setup/20-ipc-lcd-services.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2017 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    20-ipc-lcd-services.sh
+#  \brief   Toggle IPC LCD services that appeared after initial MVP release
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#
+
+if [ "`uname -m`" = x86_64 ]; then
+    /bin/systemctl disable lcd-boot-display
+    /bin/systemctl disable lcd-net-display
+    /bin/systemctl disable lcd-shutdown-display || true
+    /bin/systemctl disable lcd-reboot-display || true
+    /bin/systemctl disable lcd-poweroff-display || true
+    /bin/systemctl mask lcd-boot-display
+    /bin/systemctl mask lcd-net-display
+    /bin/systemctl mask lcd-shutdown-display || true
+    /bin/systemctl mask lcd-reboot-display || true
+    /bin/systemctl mask lcd-poweroff-display || true
+    /bin/systemctl disable bios-reset-button
+    /bin/systemctl mask bios-reset-button
+else
+    /bin/systemctl enable lcd-boot-display
+    /bin/systemctl enable lcd-net-display
+    /bin/systemctl enable lcd-shutdown-display || true
+    /bin/systemctl enable lcd-reboot-display || true
+    /bin/systemctl enable lcd-poweroff-display || true
+fi


### PR DESCRIPTION
Solution: add an ipc-meta-setup snippet to handle new services

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>