### PR TITLE
Problem: our systemd units need improvements

### DIFF
--- a/systemd/bios.service
+++ b/systemd/bios.service
@@ -12,6 +12,11 @@ ExecStart=/bin/systemctl start bios.target
 ExecStop=/bin/systemctl stop bios.target
 # Make sure this runs, even if there is an unclean startup/shutdown of the unit
 ExecStopPost=/bin/systemctl stop bios.target
+# ...and wait for all listed services to finish their lives
+ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p Wants bios.target | cut -d= -f2)"
+# Ordinary frozen services stop for 90 sec max (default),
+# so this service should outlive them
+TimeoutStopSec=120
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -25,6 +25,7 @@ ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service
 ExecStartPre=/bin/dash -c "if [ -d /var/lib/mysql ] ; then /bin/chown -R mysql:mysql /var/lib/mysql ; fi"
 ExecStart=/usr/lib/mysql/rcmysql start
 ExecStop=/usr/lib/mysql/rcmysql stop
+ExecStopPost=-/bin/rm -f /var/run/fty-db-ready
 # Make sure dependent services have finished, e.g. if mysqld died ungracefully
 ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundTo fty-db-engine.service | cut -d= -f2 | tr ' ' '\\n' | egrep -v '^(bios|fty)\.(service|target)$')"
 

--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -4,20 +4,29 @@
 [Unit]
 Description=MySQL server for 42ity usage
 Conflicts=mysql.service mysqld.service mariadb.service
-# Not Requires, not Requisite... Wants and ExecStartPre is-active hack, see https://github.com/systemd/systemd/issues/1312
-Wants=basic.target network.target fty-license-accepted.service
+Wants=basic.target network.target
+Requires=fty-license-accepted.service
+BindsTo=fty-license-accepted.service
 After=basic.target network.target fty-license-accepted.service
 PartOf=bios.target
 
 [Service]
 Type=forking
-#ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
-ExecStartPre=/bin/dash -c "while ! /bin/systemctl is-active fty-license-accepted.service ; do sleep 3 ; done"
+Restart=always
+# Note: time below must suffice for units that require database to
+# have stopped before this service restarts, otherwise we get a
+# "failed to schedule restart job: Transaction is destructive" !
+RestartSec=5
+# Unlimited startup...
+TimeoutStartSec=0
+# More than 90, less than in bios.service
+TimeoutStopSec=100
+ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
 ExecStartPre=/bin/dash -c "if [ -d /var/lib/mysql ] ; then /bin/chown -R mysql:mysql /var/lib/mysql ; fi"
 ExecStart=/usr/lib/mysql/rcmysql start
 ExecStop=/usr/lib/mysql/rcmysql stop
-TimeoutStartSec=0
-Restart=on-failure
+# Make sure dependent services have finished, e.g. if mysqld died ungracefully
+ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundTo fty-db-engine.service | cut -d= -f2 | tr ' ' '\\n' | egrep -v '^(bios|fty)\.(service|target)$')"
 
 [Install]
 WantedBy=bios.target

--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -1,3 +1,7 @@
+# NOTE: This unit also maintains a /var/run/fty-db-ready touch-file
+# while it is active, so components can check for its presence rather
+# than a systemd status (which is a more expensive operation).
+
 [Unit]
 Description=Initialize or update database schema for 42ity services
 After=fty-db-engine.service
@@ -22,6 +26,8 @@ EnvironmentFile=-/etc/default/fty
 EnvironmentFile=-/etc/default/fty__%n.conf
 Environment="prefix=/usr"
 ExecStart=/usr/libexec/bios/db-init
+ExecStartPost=/usr/bin/touch /var/run/fty-db-ready
+ExecStop=-/bin/rm -f /var/run/fty-db-ready
 ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundTo fty-db-init.service | cut -d= -f2 | tr ' ' '\\n' | egrep -v '^(bios|fty)\.(service|target)$')"
 
 [Install]

--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -1,28 +1,28 @@
 [Unit]
 Description=Initialize or update database schema for 42ity services
 After=fty-db-engine.service
-# Not Requires, not Requisite... Wants and ExecStartPre hack, see https://github.com/systemd/systemd/issues/1312
-Wants=fty-db-engine.service
-Conflicts=shutdown.target
+Requires=fty-db-engine.service
+BindsTo=fty-db-engine.service
+Conflicts=shutdown.target recovery.target
 PartOf=bios.target
 
 [Service]
-# it is expected that the process has to exit before systemd starts follow-up units
-Type=oneshot
+Type=simple
 User=root
 # the service shall be considered active even when all its processes exited
 RemainAfterExit=yes
-EnvironmentFile=-@prefix@/share/bios/etc/default/bios
-EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
-EnvironmentFile=-@prefix@/share/fty/etc/default/fty
-EnvironmentFile=-@prefix@/share/fty/etc/default/fty__%n.conf
-EnvironmentFile=-@sysconfdir@/default/bios
-EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
-EnvironmentFile=-@sysconfdir@/default/fty
-EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
-Environment="prefix=@prefix@"
-ExecStartPre=/bin/dash -c "while ! /bin/systemctl is-active fty-db-engine.service ; do sleep 3 ; done"
-ExecStart=@libexecdir@/@PACKAGE@/db-init
+Restart=always
+EnvironmentFile=-/usr/share/bios/etc/default/bios
+EnvironmentFile=-/usr/share/bios/etc/default/bios__%n.conf
+EnvironmentFile=-/usr/share/fty/etc/default/fty
+EnvironmentFile=-/usr/share/fty/etc/default/fty__%n.conf
+EnvironmentFile=-/etc/default/bios
+EnvironmentFile=-/etc/default/bios__%n.conf
+EnvironmentFile=-/etc/default/fty
+EnvironmentFile=-/etc/default/fty__%n.conf
+Environment="prefix=/usr"
+ExecStart=/usr/libexec/bios/db-init
+ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundTo fty-db-init.service | cut -d= -f2 | tr ' ' '\\n' | egrep -v '^(bios|fty)\.(service|target)$')"
 
 [Install]
 WantedBy=bios.target

--- a/systemd/fty-license-accepted.service
+++ b/systemd/fty-license-accepted.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Milestone for all 42ity-related services that should start after license is accepted
+# Note: Assert* may become available in a later version of systemd than what
+# we have in Debian 8; but for now we have to do the ExecStart* tricks below.
+#AssertFileNotEmpty=/var/lib/fty/license
 ConditionFileNotEmpty=/var/lib/fty/license
 Requires=multi-user.target network.target
 After=multi-user.target network.target
@@ -10,9 +13,12 @@ PartOf=bios.target
 Type=simple
 ### the service shall be considered active even when all its processes exited
 RemainAfterExit=yes
+Restart=always
 User=root
 ExecStartPre=/usr/bin/test -s /var/lib/fty/license
-ExecStart=-/bin/systemctl start bios.service
+ExecStart=/bin/dash -c "while ! /usr/bin/test -s /var/lib/fty/license ; do sleep 3 ; done"
+ExecStartPost=-/bin/systemctl start --no-block bios.service
+ExecStartPost=/bin/dash -c "/bin/systemctl start --no-block -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundBy fty-license-accepted.service | cut -d= -f2)"
 
 [Install]
 WantedBy=bios.target


### PR DESCRIPTION
Solution:
* fix stop-start dependencies of `fty-license-accepted`, `fty-db-engine`, `fty-db-init` and its consumers to happen automagically, as services are stopped nicely or daemons are killed off
* mark availability of database in usable state with a touch-file `/var/run/fty-db-ready` that scripts and programs can `stat()` easily
* fix `systemctl stop (or restart) bios` to rule them all

On a side note, found that `amqp` and `mdns` services tend to freeze during stop quite regularly. Probably they share some pathology with `gpio`, and while a quick hack of `TERM, wait, KILL` might help, the real fix should be in code. Other services usually manage to stop without freezing :)