### PR TITLE
Problem: DB consumers can start without credentials

### DIFF
--- a/systemd/biostimer-warranty-metric.service.in
+++ b/systemd/biostimer-warranty-metric.service.in
@@ -18,7 +18,7 @@ EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
-EnvironmentFile=-@sysconfdir@/default/bios-db-ro
+EnvironmentFile=@sysconfdir@/default/bios-db-ro
 PermissionsStartOnly=true
 ExecStart=@libexecdir@/@PACKAGE@/warranty-metric
 

--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -32,3 +32,4 @@ ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p Wante
 
 [Install]
 WantedBy=bios.target
+Alias=bios-db-init.service

--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -17,6 +17,8 @@ EnvironmentFile=-@sysconfdir@/default/bios
 EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
+# Note: for webserver the DB credentials file is optional,
+# since acceptance of license via REST API starts the database
 EnvironmentFile=-@sysconfdir@/default/bios-db-rw
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 PrivateTmp=true

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -478,6 +478,15 @@ verify_schema_version() {
 	return 0
 }
 
+trap_exit() {
+    RET_CODE=$?
+    echo "Syncing changes (if any) to stable storage..."
+    sync
+    return $RET_CODE
+}
+
+trap 'trap_exit' 0 1 2 3 15
+
 case "$INSTSQL_DIR" in
 	/*) [ -d "$INSTSQL_DIR" ] || { \
 			echo "Creating INSTSQL_DIR='$INSTSQL_DIR' to save copies of applied SQL files..."; \


### PR DESCRIPTION
Solutions:
* make sure db-init syncs before it is done
* make DB credentials a required EnvironmentFile for all units except tntnet@bios
* restore bios-db-init alias just I case