### PR TITLE
Problem: /var/lib/fty recreated with wrong rights, if destroyed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -482,6 +482,7 @@ SYSTEMD_PRESETS +=      42-bios-systemd.preset
 
 SYSTEMD_TMPFILES += \
                         logfiles-rights.conf \
+                        fty-core.conf \
                         fty-db-init.conf
 
 ### TODO? Add the build info (git commit, timestamp) to the header comment?

--- a/systemd/fty-core.conf
+++ b/systemd/fty-core.conf
@@ -1,0 +1,3 @@
+# create runtime directories for fty-core and further units
+d /var/lib/fty 0755 www-data sasl
+x /var/lib/fty/*


### PR DESCRIPTION
Solution: use tmpfiles to set up this directory too

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>