### PR TITLE
Problem: BIOS_NUT_USE_DMF not anymore in devel images

### DIFF
--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -525,6 +525,7 @@ mkdir -p /usr/share/fty/etc/default
 case "$IMGTYPE" in
     *devel*)
         echo "BIOS_LOG_LEVEL=LOG_DEBUG" > /usr/share/fty/etc/default/fty
+        echo "BIOS_NUT_USE_DMF=true" >> /usr/share/fty/etc/default/fty
         ;;
     *)
         echo "BIOS_LOG_LEVEL=LOG_INFO" > /usr/share/fty/etc/default/fty


### PR DESCRIPTION
Solution: Put the feature back into default config, so nut-scanner uses the DMF mode, and also matches the driver it ultimately suggests (default snmp-ups being the dmf version in this OS image)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>