### PR TITLE
Problem: have many uses for fty-envvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,9 +177,13 @@ systemd/fty-db-init.service
 systemd/fty-db-engine.service
 !systemd/fty-tntnet@.service.in
 systemd/fty-tntnet@.service
+!systemd/fty-envvars.service.in
+systemd/fty-envvars.service
 
 !tools/tntnet-ExecStartPre.sh.in
 tools/tntnet-ExecStartPre.sh
+!tools/envvars-ExecStartPre.sh.in
+tools/envvars-ExecStartPre.sh
 !tools/start-db-services.in
 tools/start-db-services
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,7 @@ GENERATEDSCRIPTS = tools/run-test-doc.sh tools/db-init \
 	tools/factory-reset-live.sh \
 	tools/start-db-services \
 	tools/verify-fs \
+	tools/envvars-ExecStartPre.sh \
 	tools/tntnet-ExecStartPre.sh \
 	setup/20-th-names.sh
 
@@ -288,7 +289,7 @@ client_SCRIPTS +=	 \
 			tools/start-db-services \
 			tools/fty-route
 
-helper_SCRIPTS +=	tools/tntnet-ExecStartPre.sh tools/generate-release-details.sh tools/factory-reset-live.sh
+helper_SCRIPTS +=	tools/tntnet-ExecStartPre.sh tools/envvars-ExecStartPre.sh tools/generate-release-details.sh tools/factory-reset-live.sh
 
 EXTRA_DIST +=		tools/fake-th \
 			tools/bios-networking \
@@ -449,6 +450,7 @@ SYSTEMD_UNITS += $(SYSTEMD_UNITS_TARGET_BIOS) $(SYSTEMD_UNITS_LOWLEVEL)
 # we name ours differently here (and override during OS image generation).
 #SYSTEMD_UNITS_NOTPRESET_LOWLEVEL +=
 SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS += \
+                        fty-envvars.service \
                         fty-tntnet@.service \
                         bios-fake-th.service
 

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -502,7 +502,7 @@ sed '/<!-- Here starts the real API -->/,$!d; /<!-- Here starts the real API -->
 rm -f /etc/tntnet/bios.d/20_core.xml
 
 /bin/systemctl enable tntnet@bios
-/bin/systemctl enable tntnet@bios
+/bin/systemctl enable fty-envvars@bios
 
 # Disable logind
 /bin/systemctl disable systemd-logind

--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Tntnet web server instance for 42ity using @sysconfdir@/tntnet/%i.xml
-After=network.target saslauthd.service malamute.service
-Requires=saslauthd.service malamute.service
+After=network.target saslauthd.service malamute.service fty-envvars.service
+Requires=saslauthd.service malamute.service fty-envvars.service
 PartOf=bios.target
 
 [Service]
@@ -24,6 +24,7 @@ Environment='SYSTEMD_UNIT_FULLNAME=%n'
 PrivateTmp=true
 ExecStartPre=@datadir@/@PACKAGE@/scripts/tntnet-ExecStartPre.sh %i
 EnvironmentFile=-/run/tntnet-%i.env
+EnvironmentFile=-/run/fty-envvars.env
 ExecStart=/usr/bin/tntnet -c @sysconfdir@/tntnet/%i.xml
 
 [Install]

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -3,7 +3,7 @@ Description = Initial IPC setup on target system
 DefaultDependencies=no
 After = local-fs.target
 Requires = local-fs.target
-Before = bios.target fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service avahi-daemon.service
+Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service avahi-daemon.service
 #Requires = bios.target bios.service
 
 [Service]

--- a/tools/envvars-ExecStartPre.sh.in
+++ b/tools/envvars-ExecStartPre.sh.in
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2014-2017 Eaton
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+#! \file   envvars-ExecStartPre.sh(.in)
+#  \author Jim Klimov <EvgenyKlimov@Eaton.com>
+#  \brief  Not yet documented file
+
+echo "Generate common run-time environment variables file for 42ity"
+
+set -e
+
+F="/run/fty-envvars.env"
+J="/etc/release-details.json"
+JO="/etc/bios-release.json" # Backwards compatibility
+echo "Make sure the current OS image name is populated into '$F'..."
+JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
+OSIMAGE_BASENAME="OS image name is not available"
+HARDWARE_CATALOG_NUMBER="Hardware catalog number is not available"
+HARDWARE_SPEC_REVISION="Hardware spec revision is not available"
+HARDWARE_SERIAL_NUMBER="Hardware serial number is not available"
+HARDWARE_UUID="Hardware generated UUID is not available"
+
+# Empty value means "Virtualization status is not available",
+# e.g. no systemd on this box... A successfully resolved status
+# of no virtualization of this type is "none".
+VIRT_CONTAINER=""
+VIRT_HYPERVIZOR=""
+
+{ [[ -s "$J" ]] || [[ -s "$JO" ]] ; } && \
+if [[ -x "$JSONSH" ]] ; then
+    if [[ -n "${BASH-}" ]]; then
+        . "$JSONSH"
+        get_a_string_arg() { jsonsh_cli_subshell -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V") | sed 's,^"\(.*\)",\1,' ; }
+    else
+        logmsg_info "systemctl: Will fork to use JSON.sh from '$JSONSH' to cook strings"
+        get_a_string_arg() { "$JSONSH" -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V") | sed 's,^"\(.*\)",\1,' ; }
+    fi
+    get_detail() {
+        local _TMPSTR=""
+        [[ -s "$J" ]] && \
+            _TMPSTR="$(get_a_string_arg '"release-details","'"$1"'"' < "$J")" && [[ -n "${_TMPSTR}" ]] || \
+            _TMPSTR=""
+        if [[ -z "${_TMPSTR}" ]] && [[ ! -s "$J" ]] && [[ -s "$JO" ]] ; then
+            # Legacy fallback: new OS image, old uImage - no release-details yet
+            _TMPSTR="$(get_a_string_arg '"bios-release","'"$1"'"' < "$JO")" && [[ -n "${_TMPSTR}" ]] || \
+                _TMPSTR=""
+        fi
+        echo "${_TMPSTR}"
+        if [[ -n "${_TMPSTR}" ]] ; then return 0 ; else return 1; fi
+    }
+
+    TMPSTR="$(get_detail "osimage-name")" || \
+    { TMPSTR="$(get_detail "osimage-filename")" && \
+        TMPSTR="`basename "$TMPSTR" | sed 's/\.\(squashfs\|tar\|tar\..*\|tgz\|tbz2\|txz\)$//'`" ; } || \
+    TMPSTR=""
+    [[ -n "$TMPSTR" ]] && OSIMAGE_BASENAME="$TMPSTR" || true
+
+    TMPSTR="$(get_detail "hardware-catalog-number")" && \
+        HARDWARE_CATALOG_NUMBER="$TMPSTR" || true
+    TMPSTR="$(get_detail "hardware-spec-revision")" && \
+        HARDWARE_SPEC_REVISION="$TMPSTR" || true
+    TMPSTR="$(get_detail "hardware-serial-number")" && \
+        HARDWARE_SERIAL_NUMBER="$TMPSTR" || true
+    TMPSTR="$(get_detail "uuid")" && \
+        HARDWARE_UUID="$TMPSTR" || true
+    unset TMPSTR
+fi
+
+if [ -x /usr/bin/systemd-detect-virt ]; then
+    VIRT_CONTAINER="$(/usr/bin/systemd-detect-virt -c)" || VIRT_CONTAINER=""
+    VIRT_HYPERVIZOR="$(/usr/bin/systemd-detect-virt -v)" || VIRT_HYPERVIZOR=""
+fi
+
+cat << EOF > "$F"
+OSIMAGE_BASENAME='$OSIMAGE_BASENAME'
+SPOOL_DIR='${SPOOL}'
+HARDWARE_CATALOG_NUMBER='${HARDWARE_CATALOG_NUMBER}'
+HARDWARE_SPEC_REVISION='${HARDWARE_SPEC_REVISION}'
+HARDWARE_SERIAL_NUMBER='${HARDWARE_SERIAL_NUMBER}'
+HARDWARE_UUID='${HARDWARE_UUID}'
+VIRT_HYPERVIZOR='${VIRT_HYPERVIZOR}'
+VIRT_CONTAINER='${VIRT_CONTAINER}'
+EOF
+
+echo "OK"

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -74,7 +74,7 @@ SYSTEMCTL_UNITS_COMMON_EXTERNAL="mariadb mysql mysqld                   \
 # SYSTEMCTL_UNITS_COMMON_INTERNAL lists the services delivered by our project
 # TODO: legacy-metrics will be removed, drop it there
 SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   \
-                                fty-tntnet@bios                                 \
+                                fty-tntnet@bios fty-envvars                     \
                                 fty-license-accepted fty-db-init fty-db-engine  \
                                 fty-kpi-power-uptime fty-alert-list fty-asset   \
                                 fty-metric-store-cleaner fty-alert-engine       \

--- a/tools/tntnet-ExecStartPre.sh.in
+++ b/tools/tntnet-ExecStartPre.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2014-2016 Eaton
+# Copyright (C) 2014-2017 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -50,76 +50,5 @@ SPOOL=/run/tntnet-${INST}
 rm -rf "${SPOOL}"
 mkdir -p "${SPOOL}"
 chown www-data: "${SPOOL}"
-
-F="/run/tntnet-${INST}.env"
-J="/etc/release-details.json"
-JO="/etc/bios-release.json" # Backwards compatibility
-echo "Make sure the current OS image name is populated into '$F'..."
-JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
-OSIMAGE_BASENAME="OS image name is not available"
-HARDWARE_CATALOG_NUMBER="Hardware catalog number is not available"
-HARDWARE_SPEC_REVISION="Hardware spec revision is not available"
-HARDWARE_SERIAL_NUMBER="Hardware serial number is not available"
-HARDWARE_UUID="Hardware generated UUID is not available"
-
-# Empty value means "Virtualization status is not available",
-# e.g. no systemd on this box... A successfully resolved status
-# of no virtualization of this type is "none".
-VIRT_CONTAINER=""
-VIRT_HYPERVIZOR=""
-
-{ [[ -s "$J" ]] || [[ -s "$JO" ]] ; } && \
-if [[ -x "$JSONSH" ]] ; then
-    if [[ -n "${BASH-}" ]]; then
-        . "$JSONSH"
-        get_a_string_arg() { jsonsh_cli_subshell -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V") | sed 's,^"\(.*\)",\1,' ; }
-    else
-        logmsg_info "systemctl: Will fork to use JSON.sh from '$JSONSH' to cook strings"
-        get_a_string_arg() { "$JSONSH" -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V") | sed 's,^"\(.*\)",\1,' ; }
-    fi
-    get_detail() {
-        local _TMPSTR=""
-        [[ -s "$J" ]] && \
-            _TMPSTR="$(get_a_string_arg '"release-details","'"$1"'"' < "$J")" && [[ -n "${_TMPSTR}" ]] || \
-            _TMPSTR=""
-        if [[ -z "${_TMPSTR}" ]] && [[ ! -s "$J" ]] && [[ -s "$JO" ]] ; then
-            # Legacy fallback: new OS image, old uImage - no release-details yet
-            _TMPSTR="$(get_a_string_arg '"bios-release","'"$1"'"' < "$JO")" && [[ -n "${_TMPSTR}" ]] || \
-                _TMPSTR=""
-        fi
-        echo "${_TMPSTR}"
-        if [[ -n "${_TMPSTR}" ]] ; then return 0 ; else return 1; fi
-    }
-
-    TMPSTR="$(get_detail "osimage-name")" || \
-    { TMPSTR="$(get_detail "osimage-filename")" && \
-        TMPSTR="`basename "$TMPSTR" | sed 's/\.\(squashfs\|tar\|tar\..*\|tgz\|tbz2\|txz\)$//'`" ; } || \
-    TMPSTR=""
-    [[ -n "$TMPSTR" ]] && OSIMAGE_BASENAME="$TMPSTR" || true
-
-    TMPSTR="$(get_detail "hardware-catalog-number")" && \
-        HARDWARE_CATALOG_NUMBER="$TMPSTR" || true
-    TMPSTR="$(get_detail "hardware-spec-revision")" && \
-        HARDWARE_SPEC_REVISION="$TMPSTR" || true
-    TMPSTR="$(get_detail "hardware-serial-number")" && \
-        HARDWARE_SERIAL_NUMBER="$TMPSTR" || true
-    TMPSTR="$(get_detail "uuid")" && \
-        HARDWARE_UUID="$TMPSTR" || true
-    unset TMPSTR
-fi
-
-if [ -x /usr/bin/systemd-detect-virt ]; then
-    VIRT_CONTAINER="$(/usr/bin/systemd-detect-virt -c)" || VIRT_CONTAINER=""
-    VIRT_HYPERVIZOR="$(/usr/bin/systemd-detect-virt -v)" || VIRT_HYPERVIZOR=""
-fi
-
-echo "OSIMAGE_BASENAME='$OSIMAGE_BASENAME'" > "$F"
-echo "SPOOL_DIR='${SPOOL}'" >> "$F"
-echo "HARDWARE_CATALOG_NUMBER='${HARDWARE_CATALOG_NUMBER}'" >> "$F"
-echo "HARDWARE_SPEC_REVISION='${HARDWARE_SPEC_REVISION}'" >> "$F"
-echo "HARDWARE_SERIAL_NUMBER='${HARDWARE_SERIAL_NUMBER}'" >> "$F"
-echo "HARDWARE_UUID='${HARDWARE_UUID}'" >> "$F"
-echo "VIRT_HYPERVIZOR='${VIRT_HYPERVIZOR}'" >> "$F"
-echo "VIRT_CONTAINER='${VIRT_CONTAINER}'" >> "$F"
 
 echo "OK"


### PR DESCRIPTION
Solution: separate the script to generate the envvar file into a separate script and service from tntnet-ExecStartPre.sh.in

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>