### PR TITLE
Problem: fty-db-engine startup fails

### DIFF
--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -27,7 +27,7 @@ TimeoutStopSec=100
 ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
 ExecStartPre=/bin/dash -c "if [ -d /var/lib/mysql ] ; then /bin/chown -R mysql:mysql /var/lib/mysql ; fi"
 ExecStart=/usr/lib/mysql/rcmysql start
-ExecStartPost=/bin/dash -c "/usr/bin/mysql -e 'show databases;' || /usr/bin/mysql --password='' -e 'show databases;'"
+ExecStartPost=/bin/dash -c "/usr/bin/mysql -e 'show databases;' || /usr/bin/mysql --password='' -e 'show databases;' || { sleep 30 ; /usr/bin/mysql -e 'show databases;' || /usr/bin/mysql --password='' -e 'show databases;' ; }"
 ExecStop=/usr/lib/mysql/rcmysql stop
 ExecStopPost=-/bin/rm -f /var/run/fty-db-ready
 # Make sure dependent services have finished, e.g. if mysqld died ungracefully

--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -13,6 +13,9 @@ PartOf=bios.target
 [Service]
 Type=forking
 Restart=always
+# Note: explicit User=root is required for $HOME to get set and ~/.my.cnf
+# to get used by ExecStartPost self-check below
+User=root
 # Note: time below must suffice for units that require database to
 # have stopped before this service restarts, otherwise we get a
 # "failed to schedule restart job: Transaction is destructive" !


### PR DESCRIPTION
Solution: apply missed commits to facilitate its self-check