### PR TITLE
Problem: License acceptance slowed down in recent iterations

### DIFF
--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -11,7 +11,11 @@ Conflicts=shutdown.target recovery.target
 PartOf=bios.target
 
 [Service]
-Type=simple
+# Note: a "simple" service causes systemctl to proceed immediately, and
+# a "oneshot" can not have "Restart!=no"; for our purposes the "forking"
+# with "RemainAfterExit=yes" is what we need, to have the service keep
+# trying to start up indefinitely (e.g. initial boot, untouched for days).
+Type=forking
 User=root
 # the service shall be considered active even when all its processes exited
 RemainAfterExit=yes

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -30,6 +30,25 @@ SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
 #SYSTEMCTL=/usr/libexec/bios/systemctl
 #SYSTEMCTL=/bin/systemctl
 
+### Note: starting the systemctl wrapper on ARM has noticeable overhead, so we
+### clump several targets to act upon, rather than do a "clean" one-by-one run.
+### This value can be set by envvar files pulled by the service, e.g. the clean
+### mode is useful to debug problems, and has negligible overhead on X86.
+### Default is to not coalease (so to run one by one).
+case "${SYSTEMCTL_COALESCE-}" in
+    [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn]) SYSTEMCTL_COALESCE=yes ;;
+    [Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]) SYSTEMCTL_COALESCE=no ;;
+    *)  if [ -n "${SYSTEMCTL_COALESCE-}" ] ; then
+            echo "WARNING: Unknown value of SYSTEMCTL_COALESCE='$SYSTEMCTL_COALESCE', will guess one" >&2
+        fi
+        case "`uname -m | tr '[A-Z]' '[a-z]'`" in
+            *arm*)  SYSTEMCTL_COALESCE=yes ;;
+            *86*|amd64) SYSTEMCTL_COALESCE=no ;;
+            *)      SYSTEMCTL_COALESCE=no ;;
+        esac
+        ;;
+esac
+
 die () {
     echo "ERROR: `date -u`: ${@}" >&2
     exit 1
@@ -45,24 +64,42 @@ fi
 # Just in case the service is disabled by preinstall or other means,
 # make it be active (as long as the license acceptance criteria are met).
 # Otherwise it should have come up as soon as the file(s) appeared, etc.
-echo "INFO: `date -u`: enable and start fty-license-accepted.service"
-sudo ${SYSTEMCTL} unmask fty-license-accepted.service || die "Unmasking fty-license-accepted failed"
-sudo ${SYSTEMCTL} enable fty-license-accepted.service || die "Enabling fty-license-accepted failed"
-sudo ${SYSTEMCTL} restart fty-license-accepted.service || die "Restarting fty-license-accepted failed"
-sudo ${SYSTEMCTL} start fty-license-accepted.service || die "Starting fty-license-accepted failed"
 
-# Technically this all should not be needed, as the standard processing
-# of the now-active fty-license-accepted should trigger startup of the
-# database engine, then our schema, then the services which need it all.
-# But just in case, make sure they all are up before we return...
-echo "INFO: `date -u`: enable and start fty-db-engine"
-sudo ${SYSTEMCTL} unmask fty-db-engine || die "Unmasking fty-db-engine failed"
-sudo ${SYSTEMCTL} enable fty-db-engine || die "Enabling fty-db-engine failed"
-sudo ${SYSTEMCTL} start fty-db-engine || die "Starting fty-db-engine failed"
+if [ "$SYSTEMCTL_COALESCE" = no ]; then
+    echo "INFO: `date -u`: enable and start fty-license-accepted.service"
+    sudo ${SYSTEMCTL} unmask fty-license-accepted.service || die "Unmasking fty-license-accepted failed"
+    sudo ${SYSTEMCTL} enable fty-license-accepted.service || die "Enabling fty-license-accepted failed"
+    sudo ${SYSTEMCTL} restart fty-license-accepted.service || die "Restarting fty-license-accepted failed"
+    sudo ${SYSTEMCTL} start fty-license-accepted.service || die "Starting fty-license-accepted failed"
 
-echo "INFO: `date -u`: enable and start fty-db-init"
-sudo ${SYSTEMCTL} enable fty-db-init || die "Enabling fty-db-init failed"
-sudo ${SYSTEMCTL} start fty-db-init || die "Starting fty-db-init failed"
+    # Technically this all should not be needed, as the standard processing
+    # of the now-active fty-license-accepted should trigger startup of the
+    # database engine, then our schema, then the services which need it all.
+    # But just in case, make sure they all are up before we return...
+    echo "INFO: `date -u`: enable and start fty-db-engine"
+    sudo ${SYSTEMCTL} unmask fty-db-engine || die "Unmasking fty-db-engine failed"
+    sudo ${SYSTEMCTL} enable fty-db-engine || die "Enabling fty-db-engine failed"
+    sudo ${SYSTEMCTL} start fty-db-engine || die "Starting fty-db-engine failed"
+
+    echo "INFO: `date -u`: enable and start fty-db-init"
+    sudo ${SYSTEMCTL} enable fty-db-init || die "Enabling fty-db-init failed"
+    sudo ${SYSTEMCTL} start fty-db-init || die "Starting fty-db-init failed"
+else
+    echo "INFO: `date -u`: unmask core database-related services"
+    sudo ${SYSTEMCTL} unmask fty-license-accepted.service fty-db-engine.service fty-db-init.service \
+        || die "Unmasking a core database-related service failed"
+
+    echo "INFO: `date -u`: enable core database-related services"
+    sudo ${SYSTEMCTL} enable fty-license-accepted.service fty-db-engine.service fty-db-init.service \
+        || die "Enabling a core database-related service failed"
+
+    echo "INFO: `date -u`: tickle fty-license-accepted.service"
+    sudo ${SYSTEMCTL} restart fty-license-accepted.service || die "Restarting fty-license-accepted failed"
+
+    echo "INFO: `date -u`: start core database-related services"
+    sudo ${SYSTEMCTL} start fty-license-accepted.service fty-db-engine.service fty-db-init.service \
+        || die "Starting a core database-related service failed"
+fi
 
 sleep 2
 
@@ -131,29 +168,53 @@ DB_CONSUMERS="`list_db_consumers`" || DB_CONSUMERS=""
 if [ -z "$DB_CONSUMERS" ]; then
     echo "WARNING: No services were found to be direct or further consumers of (fty|bios)-db-init.service" >&2
 else
-    echo "INFO: The following services were found to be direct or further consumers of (fty|bios)-db-init.service: $DB_CONSUMERS" >&2
-    for SERVICE in $DB_CONSUMERS ; do
-        echo "INFO: `date -u`: enable and start ${SERVICE}"
-        sudo ${SYSTEMCTL} enable "${SERVICE}" || echo "WARNING: Could not enable '${SERVICE}', is it a component of IPM Infra?"
-        sudo ${SYSTEMCTL} start "${SERVICE}" || echo "WARNING: Could not start '${SERVICE}', is it a component of IPM Infra?"
-    done
+    echo "INFO: The following DB_CONSUMERS services were found to be direct or further consumers of (fty|bios)-db-init.service: $DB_CONSUMERS" >&2
+    if [ "$SYSTEMCTL_COALESCE" = no ]; then
+        for SERVICE in $DB_CONSUMERS ; do
+            echo "INFO: `date -u`: enable and start ${SERVICE}"
+            sudo ${SYSTEMCTL} enable "${SERVICE}" || echo "WARNING: Could not enable '${SERVICE}', is it a component of IPM Infra?"
+            sudo ${SYSTEMCTL} start "${SERVICE}" || echo "WARNING: Could not start '${SERVICE}', is it a component of IPM Infra?"
+        done
+    else
+        echo "INFO: `date -u`: enable DB_CONSUMERS"
+        sudo ${SYSTEMCTL} enable $DB_CONSUMERS || echo "WARNING: Could not enable one of DB_CONSUMERS, is it a component of IPM Infra?"
+
+        echo "INFO: `date -u`: start DB_CONSUMERS"
+        sudo ${SYSTEMCTL} start $DB_CONSUMERS || echo "WARNING: Could not enable one of DB_CONSUMERS, is it a component of IPM Infra?"
+    fi
 fi
 echo "INFO: `date -u`: Done starting database services and their consumers: OK"
 
 echo "INFO: `date -u`: enable and start bios.service and bios.target for the remaining IPM Infra services"
-sudo ${SYSTEMCTL} enable bios.service
-sudo ${SYSTEMCTL} enable bios.target
-sudo ${SYSTEMCTL} start bios.service --no-block || die "Could not issue startup request for bios.service"
-sudo ${SYSTEMCTL} start bios.target --no-block || die "Could not issue startup request for bios.target"
+if [ "$SYSTEMCTL_COALESCE" = no ]; then
+    sudo ${SYSTEMCTL} enable bios.service
+    sudo ${SYSTEMCTL} enable bios.target
+    sudo ${SYSTEMCTL} start bios.service --no-block || die "Could not issue startup request for bios.service"
+    sudo ${SYSTEMCTL} start bios.target --no-block || die "Could not issue startup request for bios.target"
+else
+    sudo ${SYSTEMCTL} enable bios.service bios.target
+    sudo ${SYSTEMCTL} start bios.service bios.target --no-block || die "Could not issue startup request for bios.target or bios.service"
+fi
 
 # NOTE: we have tntnet@bios.service officially aliased by fty-tntnet@bios.service
 # They happen to conflict if both are "enabled", so we "sed" away to collapse 'em
-echo "INFO: `date -u`: Start units WantedBy and/or PartOf bios.target, if any were missed by previous attempts"
-for SERVICE in `/bin/systemctl show -p Wants -p ConsistsOf bios.target | cut -d= -f2 | tr ' ' '\n' | sed -e 's,^fty-tntnet,tntnet,' | sort | uniq` ; do
-        echo "INFO: `date -u`: enable and start ${SERVICE}"
-        ( sudo ${SYSTEMCTL} enable "${SERVICE}" ) || echo "WARNING: Could not enable '${SERVICE}', is it a component of IPM Infra?"
-        ( sudo ${SYSTEMCTL} start "${SERVICE}"  ) || echo "WARNING: Could not start '${SERVICE}', is it a component of IPM Infra?"
-done
+BIOS_DEPS="`/bin/systemctl show -p Wants -p ConsistsOf bios.target | cut -d= -f2 | tr ' ' '\n' | sed -e 's,^fty-tntnet,tntnet,' | sort | uniq`" || BIOS_DEPS=""
+if [ -n "$BIOS_DEPS" ]; then
+    echo "INFO: `date -u`: Request to start BIOS_DEPS units WantedBy and/or PartOf bios.target, if any were missed by previous attempts: $BIOS_DEPS"
+    if [ "$SYSTEMCTL_COALESCE" = no ]; then
+        for SERVICE in $BIOS_DEPS ; do
+            echo "INFO: `date -u`: enable and start ${SERVICE}"
+            ( sudo ${SYSTEMCTL} enable "${SERVICE}" ) || echo "WARNING: Could not enable '${SERVICE}', is it a component of IPM Infra?"
+            ( sudo ${SYSTEMCTL} start "${SERVICE}"  ) || echo "WARNING: Could not start '${SERVICE}', is it a component of IPM Infra?"
+        done
+    else
+        echo "INFO: `date -u`: enable BIOS_DEPS"
+        sudo ${SYSTEMCTL} enable $BIOS_DEPS || echo "WARNING: Could not enable one of BIOS_DEPS, is it a component of IPM Infra?"
+
+        echo "INFO: `date -u`: start BIOS_DEPS"
+        sudo ${SYSTEMCTL} start $BIOS_DEPS || echo "WARNING: Could not start one of BIOS_DEPS, is it a component of IPM Infra?"
+    fi
+fi
 
 echo "INFO: `date -u`: Done starting IPM Infra services: OK"
 exit 0

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -16,7 +16,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #! \file   start-db-services(.in)
-#  \brief  Start and enable all services dependent on bios-db-init/fty-db-init service
+#  \brief  Start and enable all services dependent on bios-db-init/fty-db-init
+#          services; this helper is called from REST API for license acceptance
 #  \author Michal Vyskocil <MichalVyskocil@eaton.com>
 #  \author Jim Klimov <EvgenyKlimov@eaton.com>
 

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -31,7 +31,7 @@ SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
 #SYSTEMCTL=/bin/systemctl
 
 die () {
-    echo "ERROR: ${@}" >&2
+    echo "ERROR: `date -u`: ${@}" >&2
     exit 1
 }
 
@@ -124,6 +124,8 @@ list_db_consumers() {
     fi
     echo "${ARR_GRAND_CONSUMERS[@]}"
 }
+
+echo "INFO: `date -u`: Finding database services and their consumers to ensure their startup..."
 
 DB_CONSUMERS="`list_db_consumers`" || DB_CONSUMERS=""
 if [ -z "$DB_CONSUMERS" ]; then

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -38,7 +38,7 @@ SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
 case "${SYSTEMCTL_COALESCE-}" in
     [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn]) SYSTEMCTL_COALESCE=yes ;;
     [Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]) SYSTEMCTL_COALESCE=no ;;
-    *)  if [ -n "${SYSTEMCTL_COALESCE-}" ] ; then
+    *)  if [[ -n "${SYSTEMCTL_COALESCE-}" ]] ; then
             echo "WARNING: Unknown value of SYSTEMCTL_COALESCE='$SYSTEMCTL_COALESCE', will guess one" >&2
         fi
         case "`uname -m | tr '[A-Z]' '[a-z]'`" in
@@ -65,7 +65,7 @@ fi
 # make it be active (as long as the license acceptance criteria are met).
 # Otherwise it should have come up as soon as the file(s) appeared, etc.
 
-if [ "$SYSTEMCTL_COALESCE" = no ]; then
+if [[ "$SYSTEMCTL_COALESCE" = no ]] ; then
     echo "INFO: `date -u`: enable and start fty-license-accepted.service"
     sudo ${SYSTEMCTL} unmask fty-license-accepted.service || die "Unmasking fty-license-accepted failed"
     sudo ${SYSTEMCTL} enable fty-license-accepted.service || die "Enabling fty-license-accepted failed"
@@ -141,7 +141,7 @@ find_svc_consumers_recursive() {
             *) SEEK_SERVICE="(${SERVICE}|${SERVICE}.(service|timer|path|target))" ;;
         esac
         for ix in ${!ARR_GRAND_CONSUMERS[*]} ; do
-            if [ x"${ARR_GRAND_CONSUMERS[$ix]}" = x"${SERVICE}" ] ; then
+            if [[ x"${ARR_GRAND_CONSUMERS[$ix]}" = x"${SERVICE}" ]] ; then
                 # This service is already detected, go process next one
 #                echo "DEBUG: find_svc_consumers_recursive( '$1' ): SKIPPED ${SERVICE}..." >&2
                 continue 2
@@ -156,7 +156,7 @@ find_svc_consumers_recursive() {
 list_db_consumers() {
     ARR_GRAND_CONSUMERS=( )
     find_svc_consumers_recursive '(fty|bios)-db-init.service' || return
-    if [ 0 == "${#ARR_GRAND_CONSUMERS[@]}" ] ; then
+    if [[ 0 == "${#ARR_GRAND_CONSUMERS[@]}" ]] ; then
         return 22
     fi
     echo "${ARR_GRAND_CONSUMERS[@]}"
@@ -165,11 +165,11 @@ list_db_consumers() {
 echo "INFO: `date -u`: Finding database services and their consumers to ensure their startup..."
 
 DB_CONSUMERS="`list_db_consumers`" || DB_CONSUMERS=""
-if [ -z "$DB_CONSUMERS" ]; then
+if [[ -z "$DB_CONSUMERS" ]] ; then
     echo "WARNING: No services were found to be direct or further consumers of (fty|bios)-db-init.service" >&2
 else
     echo "INFO: The following DB_CONSUMERS services were found to be direct or further consumers of (fty|bios)-db-init.service: $DB_CONSUMERS" >&2
-    if [ "$SYSTEMCTL_COALESCE" = no ]; then
+    if [[ "$SYSTEMCTL_COALESCE" = no ]] ; then
         for SERVICE in $DB_CONSUMERS ; do
             echo "INFO: `date -u`: enable and start ${SERVICE}"
             sudo ${SYSTEMCTL} enable "${SERVICE}" || echo "WARNING: Could not enable '${SERVICE}', is it a component of IPM Infra?"
@@ -186,7 +186,7 @@ fi
 echo "INFO: `date -u`: Done starting database services and their consumers: OK"
 
 echo "INFO: `date -u`: enable and start bios.service and bios.target for the remaining IPM Infra services"
-if [ "$SYSTEMCTL_COALESCE" = no ]; then
+if [[ "$SYSTEMCTL_COALESCE" = no ]] ; then
     sudo ${SYSTEMCTL} enable bios.service
     sudo ${SYSTEMCTL} enable bios.target
     sudo ${SYSTEMCTL} start bios.service --no-block || die "Could not issue startup request for bios.service"
@@ -199,9 +199,9 @@ fi
 # NOTE: we have tntnet@bios.service officially aliased by fty-tntnet@bios.service
 # They happen to conflict if both are "enabled", so we "sed" away to collapse 'em
 BIOS_DEPS="`/bin/systemctl show -p Wants -p ConsistsOf bios.target | cut -d= -f2 | tr ' ' '\n' | sed -e 's,^fty-tntnet,tntnet,' | sort | uniq`" || BIOS_DEPS=""
-if [ -n "$BIOS_DEPS" ]; then
+if [[ -n "$BIOS_DEPS" ]] ; then
     echo "INFO: `date -u`: Request to start BIOS_DEPS units WantedBy and/or PartOf bios.target, if any were missed by previous attempts: $BIOS_DEPS"
-    if [ "$SYSTEMCTL_COALESCE" = no ]; then
+    if [[ "$SYSTEMCTL_COALESCE" = no ]] ; then
         for SERVICE in $BIOS_DEPS ; do
             echo "INFO: `date -u`: enable and start ${SERVICE}"
             ( sudo ${SYSTEMCTL} enable "${SERVICE}" ) || echo "WARNING: Could not enable '${SERVICE}', is it a component of IPM Infra?"

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -25,8 +25,10 @@ exec > /tmp/start-db-services.log 2>&1
 set -x
 
 ### Prefer to use our wrapper that limits impact to permitted targets
-#SYSTEMCTL=/bin/systemctl
 SYSTEMCTL=@libexecdir@/@PACKAGE@/systemctl
+#SYSTEMCTL=/usr/libexec/fty/systemctl
+#SYSTEMCTL=/usr/libexec/bios/systemctl
+#SYSTEMCTL=/bin/systemctl
 
 die () {
     echo "ERROR: ${@}" >&2


### PR DESCRIPTION
Solution: after some looking at logs, the hundreds of looped calls to `systemctl` (making sure all DB dependants are started, even when systemd does not do its job right) amounted to a large overhead. Since we can instead pass many arguments to one call, do so by default on ARM. Startup cut from ~4min to 1m20s, including 1m5s of DB files and schema creation and initialization.