### PR TITLE
Problem: bios user still is not in gpio group

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -361,6 +361,7 @@ ipc_meta_setupdir = $(datadir)/@PACKAGE@/setup/
 # Note: use srcdir for verbatim scripts, builddir for templated .sh.in products
 ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/10-avahi-lxc.sh \
+	$(top_srcdir)/setup/10-bios-gpio.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
@@ -369,6 +370,7 @@ ipc_meta_setup_SCRIPTS = \
 
 EXTRA_DIST += \
 	$(top_srcdir)/setup/10-avahi-lxc.sh \
+	$(top_srcdir)/setup/10-bios-gpio.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -91,8 +91,8 @@ useradd -m bios -N -g bios-infra -G dialout -s /bin/bash
 mkdir -p /home/bios && chown bios:bios-infra /home/bios
 
 # Create a GPIO group to access GPIO pins, and add the user bios
-groupadd --system gpio
-usermod -G gpio bios
+groupadd --system -f gpio
+usermod -G gpio -a bios
 
 # add an access to sasl, bios-logread (for /var/log/messages) and systemd journal
 # note that earlier OS images had custom logs owned by "adm" group, so we also
@@ -105,10 +105,10 @@ EOF
 mkdir -p /home/admin && chown admin:bios-admin /home/admin
 
 # add an access to bios-logread (for /var/log/messages) to webserver
-usermod -G bios-logread www-data
+usermod -G bios-logread -a www-data
 
 # add an access to sasl for bios
-usermod -G "${SASL_GROUP}" bios
+usermod -G "${SASL_GROUP}" -a bios
 
 # TODO: See if "sudo"able tasks that this account may have to do can be done
 # with another shell like /bin/nologin or /bin/false - and then secure it...

--- a/setup/10-bios-gpio.sh
+++ b/setup/10-bios-gpio.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2017 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    10-bios-gpio.sh
+#  \brief   Make sure "bios" user ends up in a "gpio" group
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#
+#   Note: this seems to duplicate functionality in the preinstall script,
+#   but 1) it does not seem to always work (group appears but stays empty
+#   in OS image), and 2) it was not there when earlier releases were made.
+
+BIOS_USER="bios"
+GPIO_GROUP="gpio"
+
+die() {
+    echo "FATAL: $*" >&2
+    exit 1
+}
+
+skip() {
+    echo "SKIP: $*" >&2
+    exit 0
+}
+
+getent passwd "${BIOS_USER}" >/dev/null \
+|| die "The '${BIOS_USER}' user account is not defined in this system"
+
+getent group "${GPIO_GROUP}" >/dev/null \
+|| groupadd --system --force "${GPIO_GROUP}" || die "Failed to create the '${GPIO_GROUP}' system group"
+
+getent group "${GPIO_GROUP}" >/dev/null \
+|| die "The '${GPIO_GROUP}' group account is not defined in this system"
+
+getent group "${GPIO_GROUP}" \
+| sed -e 's,^.*:\([^:]*\)$,\1,' \
+| egrep '(^'"${BIOS_USER}"'$|^'"${BIOS_USER}"',|,'"${BIOS_USER}"'$|,'"${BIOS_USER}"',)' \
+&& skip "The '${BIOS_USER}' user account is already a member of '${GPIO_GROUP}' group"
+
+usermod -G "${GPIO_GROUP}" "${BIOS_USER}"

--- a/setup/10-bios-gpio.sh
+++ b/setup/10-bios-gpio.sh
@@ -54,4 +54,4 @@ getent group "${GPIO_GROUP}" \
 | egrep '(^'"${BIOS_USER}"'$|^'"${BIOS_USER}"',|,'"${BIOS_USER}"'$|,'"${BIOS_USER}"',)' \
 && skip "The '${BIOS_USER}' user account is already a member of '${GPIO_GROUP}' group"
 
-usermod -G "${GPIO_GROUP}" "${BIOS_USER}"
+usermod -G "${GPIO_GROUP}" -a "${BIOS_USER}"

--- a/tools/init-os-accounts.sh
+++ b/tools/init-os-accounts.sh
@@ -255,7 +255,7 @@ genUser() {
     # but don't die if this fails
     for G in $USER_ADD_GROUPS ; do
 	echo "INFO: Try to add '$G' as a secondary group for '$USER_NAME' (may fail)..."
-	$RUNAS usermod -G "$G" "$USER_NAME"
+	$RUNAS usermod -G "$G" -a "$USER_NAME"
     done
 
     return $RES_U


### PR DESCRIPTION
Solution: add a setup/10-bios-gpio.sh scriptlet for ipc-meta-setup to take care of this on boot; this would also help upgrades

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

See caveats in #187 - not an issue for our current focus, but can become one when we expand