### PR TITLE
Problem: OS images generate different GIDs and NUT complains

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -366,6 +366,7 @@ ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_builddir)/setup/20-th-names.sh \
+	$(top_srcdir)/setup/90-nut-ownership.everytime.sh \
 	$(top_srcdir)/setup/ipc-meta-setup.sh
 
 EXTRA_DIST += \
@@ -375,6 +376,7 @@ EXTRA_DIST += \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_srcdir)/setup/20-th-names.sh.in \
+	$(top_srcdir)/setup/90-nut-ownership.everytime.sh \
 	$(top_srcdir)/setup/ipc-meta-setup.sh
 
 # SystemD integrations files; if not enabled - variables remain empty

--- a/setup/90-nut-ownership.everytime.sh
+++ b/setup/90-nut-ownership.everytime.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2017 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    90-nut-ownership.everytime.sh
+#  \brief   Make sure NUT configuration and data locations are owned
+#           by proper account names even if name-to-number mapping has
+#           changed in the user database
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+
+NUT_USER="nut"
+NUT_GROUP="nut"
+
+die() {
+    echo "FATAL: $*" >&2
+    exit 1
+}
+
+skip() {
+    echo "SKIP: $*" >&2
+    exit 0
+}
+
+getent passwd "${NUT_USER}" >/dev/null \
+|| die "The '${NUT_USER}' user account is not defined in this system"
+
+getent group "${NUT_GROUP}" >/dev/null \
+|| die "The '${NUT_GROUP}' group account is not defined in this system"
+
+RES=0
+for D in /run/nut /var/run/nut /var/state/nut /var/state/ups ; do
+    if [ -d "$D" ] ; then
+        chown -R nut:nut "$D" || true
+        chown root "$D" || true
+        chmod 770 "$D" || true
+    fi
+done
+
+chgrp -R nut /var/lib/nut || RES=$?
+chown root /var/lib/nut || RES=$?
+chmod 770 /var/lib/nut || RES=$?
+
+chgrp -R nut /etc/nut || RES=$?
+chown -R root /etc/nut || RES=$?
+chmod -R 640 /etc/nut || RES=$?
+chmod 755 /etc/nut || RES=$?
+
+exit $RES


### PR DESCRIPTION
Solution: as a quick hotfix, always apply proper ownership to NUT configs and runtime files

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>