### PR TITLE
Add Forceflash support to update-rc3

### DIFF
--- a/tools/update-rc3
+++ b/tools/update-rc3
@@ -216,6 +216,9 @@ usage() {
     echo "  --forceflash | -FF, --forceflash-image-os | -FFo, --forceflash-image-fw | -FFf"
     echo "      --forceflash-image-u-Boot | -FFb, --forceflash-image-uImage | -FFi"
     echo "                   Touch the .forceflash flag-files for corresponding new image"
+    echo "  --no-forceflash | -NFF      Remove all existing .forceflash flag-files before"
+    echo "                   anything else (if other --forceflash* options are enabled,"
+    echo "                   they can later repopulate corresponding touch-files)"
     echo "  --reboot | -r | -R         If a new image (OS, FW) downloaded successfully"
     echo "                   request an immediate reboot as part of this script"
     echo "                   With '-R' this reboots the system in either non-error case"
@@ -1658,6 +1661,9 @@ ACTION_CHECK_FWIMAGE="no"
 ACTION_FORCEFLASH_OSIMAGE="no"
 ACTION_FORCEFLASH_FWIMAGE_UBOOT="no"
 ACTION_FORCEFLASH_FWIMAGE_UIMAGE="no"
+# Remove any existing .forceflash flag-files before any check or download
+# (does not fire for a mere "-ls" activity)
+ACTION_FORCEFLASH_CLEANUP="no"
 
 # The routines can force a specific URL rather than detecting the "newest" one
 [ -z "${URL_DOWNLOAD_OSIMAGE-}" ] &&                URL_DOWNLOAD_OSIMAGE=""
@@ -1803,6 +1809,8 @@ while [ $# -gt 0 ]; do
 		--erase-all)            FLAG_ERASE_ALL="yes" ;;
 		--touch-erase-all|--force-erase-all)
 		                        FLAG_ERASE_ALL="force" ;;
+		--no-forceflash|--no-FF|-NFF)
+		                        ACTION_FORCEFLASH_CLEANUP="yes" ;;
 		--forceflash-image|-FF)
 		                        ACTION_FORCEFLASH_OSIMAGE="yes"
 		                        ACTION_FORCEFLASH_FWIMAGE_UBOOT="yes"
@@ -1849,6 +1857,12 @@ while [ $# -gt 0 ]; do
 	esac
 	shift
 done
+
+if [ x"$ACTION_FORCEFLASH_CLEANUP" = xyes ]; then
+	rm -f "${DEPLOYMENTROOTFW_UBOOT}/u-Boot.forceflash" "${DOWNLOADROOTFW_UBOOT}/u-Boot.forceflash"
+	rm -f "${DEPLOYMENTROOTFW_UIMAGE}/uImage.forceflash" "${DOWNLOADROOTFW_UIMAGE}/uImage.forceflash"
+	rm -f "${DEPLOYMENTROOT_OSIMAGE}"/*.forceflash "${DOWNLOADROOT_OSIMAGE}"/*.forceflash
+fi
 
 # Checks are special - after we do all which were requested (if any), we exit
 if [ x"$ACTION_CHECK_OSIMAGE" = xyes ] || [ x"$ACTION_CHECK_FWIMAGE" = xyes ]; then

--- a/tools/update-rc3
+++ b/tools/update-rc3
@@ -213,6 +213,9 @@ usage() {
     echo "  --(no-)erase-all           If a new OS image downloaded successfully, then"
     echo "                   request a factory reset and(!) NAND format after reboot"
     echo "  --touch-erase-all          Enforce a factory reset + NAND format next boot"
+    echo "  --forceflash | -FF, --forceflash-image-os | -FFo, --forceflash-image-fw | -FFf"
+    echo "      --forceflash-image-u-Boot | -FFb, --forceflash-image-uImage | -FFi"
+    echo "                   Touch the .forceflash flag-files for corresponding new image"
     echo "  --reboot | -r | -R         If a new image (OS, FW) downloaded successfully"
     echo "                   request an immediate reboot as part of this script"
     echo "                   With '-R' this reboots the system in either non-error case"
@@ -386,7 +389,8 @@ remove_image() {
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"'\.[^\:]*'
     rm -f "$1"{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512}{,-padded}{,.tmp} ${2:+"$2"}
-    [ -n "$RETAIN_FILE" ] && [ -s "$RETAIN_FILE.$$" ] && mv -f "$RETAIN_FILE.$$" "$RETAIN_FILE"
+    [ -n "$RETAIN_FILE" ] && [ -s "$RETAIN_FILE.$$" ] && mv -f "$RETAIN_FILE.$$" "$RETAIN_FILE" \
+        || rm -f "$1.forceflash"
 }
 
 verify_checksum() {
@@ -736,6 +740,8 @@ download_osimage() (
     # found on this local system, then the routine just returns code "42"
     # instead of downloading this detected new image otherwise.
     # A successful download of an image (consistent non-empty file) is 42 too
+    REFER_NEWEST="${TEMP_DATA}/.newest-osimage"
+    rm -f "${REFER_NEWEST}"
 
     # We do not download OS images into NAND (like FW image fallback),
     # not by easy default at least
@@ -836,7 +842,9 @@ download_osimage() (
     if [ x"$rTGT_FILE" != x"$rIMAGE_URL_BASENAME_EXT" ] ; then
         if [ -s "$aTGT_FILE_CSNEW" ] && [ x"$aTGT_FILE_CSNEW" != x"${aIMAGE_CSNEW}" ]; then
             logmsg_info "Verifying if we have this checksum and corresponding file under flat name of data and checksum files..."
-            verify_threeway_checksum "${IMAGE_URL}" "${rTGT_FILE}" "${rTGT_FILE_CSOLD}" "${aTGT_FILE_CSNEW}" && return 0
+            verify_threeway_checksum "${IMAGE_URL}" "${rTGT_FILE}" "${rTGT_FILE_CSOLD}" "${aTGT_FILE_CSNEW}" \
+                && { echo "`pwd`/${rTGT_FILE}" > "${REFER_NEWEST}" ;
+                     return 0 ; }
             if [ -d "${DEPLOYMENTROOT_OSIMAGE}" ] ; then
                 # Do not remove deployed files!
                 logmsg_info "Verifying if we have this checksum and corresponding file already deployed..."
@@ -844,11 +852,15 @@ download_osimage() (
                     "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" \
                     "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE_CSOLD}" \
                     "${aTGT_FILE_CSNEW}" \
-                && { echo "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage"; return 0; }
+                && { echo "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ;
+                     echo "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" > "${REFER_NEWEST}" ;
+                     return 0 ; }
             fi
         fi
         logmsg_info "Verifying if we have this checksum and corresponding file under flat name of data and original name of checksum file..."
-        verify_threeway_checksum "${IMAGE_URL}" "${rTGT_FILE}" "${rTGT_FILE_CSOLD}" "${aIMAGE_CSNEW}" && return 0
+        verify_threeway_checksum "${IMAGE_URL}" "${rTGT_FILE}" "${rTGT_FILE_CSOLD}" "${aIMAGE_CSNEW}" \
+                && { echo "`pwd`/${rTGT_FILE}" > "${REFER_NEWEST}" ;
+                     return 0 ; }
         if [ -d "${DEPLOYMENTROOT_OSIMAGE}" ] ; then
             # Do not remove deployed files!
             logmsg_info "Verifying if we have this checksum and corresponding file already deployed..."
@@ -856,14 +868,18 @@ download_osimage() (
                 "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" \
                 "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE_CSOLD}" \
                 "${aIMAGE_CSNEW}" \
-                && { echo "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage"; return 0; }
+                && { echo "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ;
+                     echo "${DEPLOYMENTROOT_OSIMAGE}/${rTGT_FILE}" > "${REFER_NEWEST}" ;
+                     return 0 ; }
         fi
     fi
 
     # Then try unmodified filenames in local directories (e.g. USB download)
     logmsg_info "Verifying if we have this checksum and corresponding file under original name in base dir..."
     verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME_EXT}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" \
-    && { echo "${rIMAGE_URL_BASENAME_EXT}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage"; return 0; }
+        && { echo "${rIMAGE_URL_BASENAME_EXT}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ;
+             echo "`pwd`/${rIMAGE_URL_BASENAME_EXT}" > "${REFER_NEWEST}" ;
+             return 0; }
     if [ -d "${DEPLOYMENTROOT_OSIMAGE}" ] ; then
         # Do not remove deployed files!
         logmsg_info "Verifying if we have this checksum and corresponding file already deployed..."
@@ -871,13 +887,17 @@ download_osimage() (
             "${DEPLOYMENTROOT_OSIMAGE}/${rIMAGE_URL_BASENAME_EXT}" \
             "${DEPLOYMENTROOT_OSIMAGE}/${rIMAGE_CSOLD}" \
             "${aIMAGE_CSNEW}" \
-        && { echo "${DEPLOYMENTROOT_OSIMAGE}/${rIMAGE_URL_BASENAME_EXT}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage"; return 0; }
+        && { echo "${DEPLOYMENTROOT_OSIMAGE}/${rIMAGE_URL_BASENAME_EXT}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ;
+             echo "${DEPLOYMENTROOT_OSIMAGE}/${rIMAGE_URL_BASENAME_EXT}" > "${REFER_NEWEST}" ;
+             return 0; }
     fi
     if [ -d "./$IMGTYPE/$ARCH" ]; then
         # Bit of support for container hosts
         logmsg_info "Verifying if we have this checksum and corresponding file under original name in hierarchy..."
         verify_threeway_checksum "${IMAGE_URL}" "./$IMGTYPE/$ARCH/${rIMAGE_URL_BASENAME_EXT}" "./$IMGTYPE/$ARCH/${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" \
-        && { echo "`pwd`/$IMGTYPE/$ARCH/${rIMAGE_URL_BASENAME_EXT}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage"; return 0; }
+        && { echo "`pwd`/$IMGTYPE/$ARCH/${rIMAGE_URL_BASENAME_EXT}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ;
+             echo "`pwd`/$IMGTYPE/$ARCH/${rIMAGE_URL_BASENAME_EXT}" > "${REFER_NEWEST}" ;
+             return 0; }
     fi
 
     if [ x"${CHECK_ONLY-}" = xyes ]; then
@@ -929,6 +949,7 @@ download_osimage() (
     ls -ld "${aTGT_FILE}" "${aTGT_FILE_CSOLD}" && \
     cat "${aTGT_FILE_CSOLD}" && \
     { echo "${aTGT_FILE}" > "$DOWNLOADROOT_OSIMAGE/.newest-osimage";
+      echo "${aTGT_FILE}" > "${REFER_NEWEST}";
       return 42; }
 )
 
@@ -938,6 +959,12 @@ removeold_osimage() (
     # This removes all but the newest (alphabetically) files for the pattern
     # TODO: add support for hierarchical namespace (container hosts) with
     #       flattened or original filenames inside
+    if [ -z "$DOWNLOADED_OS_IMAGE" ] ; then
+        [ -s "${TEMP_DATA}/.newest-osimage" ] \
+        && DOWNLOADED_OS_IMAGE="`head -1 "${TEMP_DATA}/.newest-osimage"`" \
+        && [ -n "$DOWNLOADED_OS_IMAGE" ] && [ -s "$DOWNLOADED_OS_IMAGE" ] \
+        || DOWNLOADED_OS_IMAGE=""
+    fi
     VICTIMS=0
     if [ x"$FLAG_FLATTEN_FILENAMES" = xno ] ; then
         [ -d "./$IMGTYPE/$ARCH" ] && cd "./$IMGTYPE/$ARCH"
@@ -998,6 +1025,9 @@ findnewest_rawfwimage_uboot() (
 )
 
 download_rawfwimage_uboot() (
+    REFER_NEWEST="${TEMP_DATA}/.newest-uboot"
+    rm -f "${REFER_NEWEST}"
+
     cd "${DOWNLOADROOTFW_UBOOT}" || \
     cd "${DEPLOYMENTROOTFW_UBOOT}" || die "Can not use DOWNLOADROOTFW_UBOOT='$DOWNLOADROOTFW_UBOOT' nor DEPLOYMENTROOTFW_UBOOT='$DEPLOYMENTROOTFW_UBOOT'"
 
@@ -1061,19 +1091,25 @@ download_rawfwimage_uboot() (
 
     # Try the filenames in local directories
     logmsg_info "Verifying if we have this checksum and corresponding file under original name in base dir..."
-    verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" && return 0
+    verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" \
+        && { echo "`pwd`/${rIMAGE_URL_BASENAME}" > "${REFER_NEWEST}" ;
+             return 0 ; }
     if [ -s "${aIMAGE_CSNEW_PADDED}" ] && [ -c "/dev/mtd$UBOOT_MTD" ]; then
         logmsg_info "Verify padded checksum against a raw u-Boot loader partition with flashed bits here ..."
         REPLACE_MISSING_CHECKSUM="no" FLAG_CAN_REMOVE_IMAGES="no" verify_threeway_checksum "${IMAGE_URL}" \
             "/dev/mtd$UBOOT_MTD" \
             "${DEPLOYMENTROOTFW_UBOOT}/${rIMAGE_CSOLD_PADDED}" \
-            "${aIMAGE_CSNEW_PADDED}" && return 0
+            "${aIMAGE_CSNEW_PADDED}" \
+        && { echo "/dev/mtd$UBOOT_MTD" > "${REFER_NEWEST}" ;
+             return 0 ; }
     fi
     logmsg_info "Verify non-padded checksum against a raw u-Boot loader partition with flashed bits here ..."
     REPLACE_MISSING_CHECKSUM="no" FLAG_CAN_REMOVE_IMAGES="no" verify_threeway_checksum "${IMAGE_URL}" \
             "/dev/mtd$UBOOT_MTD" \
             "${DEPLOYMENTROOTFW_UBOOT}/${rIMAGE_CSOLD}" \
-            "${aIMAGE_CSNEW}" && return 0
+            "${aIMAGE_CSNEW}" \
+        && { echo "/dev/mtd$UBOOT_MTD" > "${REFER_NEWEST}" ;
+             return 0 ; }
     logmsg_warn "TODO: If we can detect the file size of the remote image, use calculate_stream_checksum_bytes() to verify flashed bits"
 
     if [ x"${CHECK_ONLY-}" = xyes ]; then
@@ -1133,15 +1169,24 @@ download_rawfwimage_uboot() (
     logmsg_info "Got u-Boot loader image OK:" && \
     ls -ld "${aTGT_FILE}" "${aIMAGE_CSOLD}" && \
     cat "${aIMAGE_CSOLD}" && \
-    return 42
+    { echo "${aTGT_FILE}" > "${REFER_NEWEST}" ;
+      return 42 ; }
 )
 
 removeold_rawfwimage_uboot() (
-    cd "${DOWNLOADROOTFW_UBOOT}" || die "Can not use DOWNLOADROOTFW_UBOOT='$DOWNLOADROOTFW_UBOOT'"
-    logmsg_info "NOTE: removeold_rawfwimage_uboot() is likely a no-op at this point"
+    cd "${DOWNLOADROOTFW_UBOOT}" || \
+    cd "${DEPLOYMENTROOTFW_UBOOT}" || die "Can not use DOWNLOADROOTFW_UBOOT='$DOWNLOADROOTFW_UBOOT' nor DEPLOYMENTROOTFW_UBOOT='$DEPLOYMENTROOTFW_UBOOT'"
+    if [ -z "$DOWNLOADED_FW_UBOOT" ] ; then
+        [ -s "${TEMP_DATA}/.newest-uboot" ] \
+        && DOWNLOADED_FW_UBOOT="`head -1 "${TEMP_DATA}/.newest-uboot"`" \
+        && [ -n "$DOWNLOADED_FW_UBOOT" ] && [ -s "$DOWNLOADED_FW_UBOOT" ] \
+        || DOWNLOADED_FW_UBOOT=""
+    fi
     VICTIMS=0
-    for F in `ls -1d u-Boot 2>/dev/null | head -n -1` ; do
-        logmsg_info "Removing older u-Boot loader image: '`pwd`/$F' and its checksum(s)"
+    for F in `ls -1d "${DOWNLOADROOTFW_UBOOT}"/u-Boot "${DEPLOYMENTROOTFW_UBOOT}"/u-Boot 2>/dev/null` ; do
+        [ -n "$DOWNLOADED_FW_UBOOT" ] && [ -s "$DOWNLOADED_FW_UBOOT" ] && [ "$DOWNLOADED_FW_UBOOT" = "$F" ] && \
+            { logmsg_info "Keeping the just-downloaded u-Boot loader image: '$DOWNLOADED_FW_UBOOT'" ; continue ; }
+        logmsg_info "Removing older u-Boot loader image: '$F' and its checksum(s)"
         remove_image "$F"
         VICTIMS=$(($VICTIMS+1))
     done
@@ -1166,6 +1211,9 @@ findnewest_rawfwimage_uimage() (
 )
 
 download_rawfwimage_uimage() (
+    REFER_NEWEST="${TEMP_DATA}/.newest-uimage"
+    rm -f "${REFER_NEWEST}"
+
     cd "${DOWNLOADROOTFW_UIMAGE}" || \
     cd "${DEPLOYMENTROOTFW_UIMAGE}" || die "Can not use DOWNLOADROOTFW_UIMAGE='$DOWNLOADROOTFW_UIMAGE' nor DEPLOYMENTROOTFW_UIMAGE='$DEPLOYMENTROOTFW_UIMAGE'"
 
@@ -1229,19 +1277,25 @@ download_rawfwimage_uimage() (
 
     # Try the filenames in local directories
     logmsg_info "Verifying if we have this checksum and corresponding file under original name in base dir..."
-    verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" && return 0
+    verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" \
+        && { echo "`pwd`/${rIMAGE_URL_BASENAME}" > "${REFER_NEWEST}" ;
+             return 0 ; }
     if [ -s "${aIMAGE_CSNEW_PADDED}" ] && [ -c "/dev/mtd$KERNEL_MTD" ]; then
         logmsg_info "Verify padded checksum against a raw kernel uImage partition with flashed bits here ..."
         REPLACE_MISSING_CHECKSUM="no" FLAG_CAN_REMOVE_IMAGES="no" verify_threeway_checksum "${IMAGE_URL}" \
             "/dev/mtd$KERNEL_MTD" \
             "${DEPLOYMENTROOTFW_UIMAGE}/${rIMAGE_CSOLD_PADDED}" \
-            "${aIMAGE_CSNEW_PADDED}" && return 0
+            "${aIMAGE_CSNEW_PADDED}" \
+        && { echo "/dev/mtd$KERNEL_MTD" > "${REFER_NEWEST}" ;
+             return 0 ; }
     fi
     logmsg_info "Verify non-padded checksum against a raw kernel uImage partition with flashed bits here ..."
     REPLACE_MISSING_CHECKSUM="no" FLAG_CAN_REMOVE_IMAGES="no" verify_threeway_checksum "${IMAGE_URL}" \
             "/dev/mtd$KERNEL_MTD" \
             "${DEPLOYMENTROOTFW_UIMAGE}/${rIMAGE_CSOLD}" \
-            "${aIMAGE_CSNEW}" && return 0
+            "${aIMAGE_CSNEW}" \
+        && { echo "/dev/mtd$KERNEL_MTD" > "${REFER_NEWEST}" ;
+             return 0 ; }
     logmsg_warn "TODO: If we can detect the file size of the remote image, use calculate_stream_checksum_bytes() to verify flashed bits"
 
     if [ x"${CHECK_ONLY-}" = xyes ]; then
@@ -1301,14 +1355,23 @@ download_rawfwimage_uimage() (
     logmsg_info "Got kernel uImage OK:" && \
     ls -ld "${aTGT_FILE}" "${aIMAGE_CSOLD}" && \
     cat "${aIMAGE_CSOLD}" && \
-    return 42
+    { echo "${aTGT_FILE}" > "${REFER_NEWEST}" ;
+      return 42 ; }
 )
 
 removeold_rawfwimage_uimage() (
-    cd "${DOWNLOADROOTFW_UIMAGE}" || die "Can not use DOWNLOADROOTFW_UIMAGE='$DOWNLOADROOTFW_UIMAGE'"
-    logmsg_info "NOTE: removeold_rawfwimage_uimage() is likely a no-op at this point"
+    cd "${DOWNLOADROOTFW_UIMAGE}" || \
+    cd "${DEPLOYMENTROOTFW_UIMAGE}" || die "Can not use DOWNLOADROOTFW_UIMAGE='$DOWNLOADROOTFW_UIMAGE' nor DEPLOYMENTROOTFW_UIMAGE='$DEPLOYMENTROOTFW_UIMAGE'"
+    if [ -z "$DOWNLOADED_FW_UIMAGE" ] ; then
+        [ -s "${TEMP_DATA}/.newest-uimage" ] \
+        && DOWNLOADED_FW_UIMAGE="`head -1 "${TEMP_DATA}/.newest-uimage"`" \
+        && [ -n "$DOWNLOADED_FW_UIMAGE" ] && [ -s "$DOWNLOADED_FW_UIMAGE" ] \
+        || DOWNLOADED_FW_UIMAGE=""
+    fi
     VICTIMS=0
-    for F in `ls -1d uImage 2>/dev/null | head -n -1` ; do
+    for F in `ls -1d "${DOWNLOADROOTFW_UIMAGE}"/uImage "${DEPLOYMENTROOTFW_UIMAGE}"/uImage 2>/dev/null` ; do
+        [ -n "$DOWNLOADED_FW_UIMAGE" ] && [ -s "$DOWNLOADED_FW_UIMAGE" ] && [ "$DOWNLOADED_FW_UIMAGE" = "$F" ] && \
+            { logmsg_info "Keeping the just-downloaded kernel uImage: '$DOWNLOADED_FW_UIMAGE'" ; continue ; }
         logmsg_info "Removing older kernel uImage: '`pwd`/$F' and its checksum(s)"
         remove_image "$F"
         VICTIMS=$(($VICTIMS+1))
@@ -1359,6 +1422,9 @@ findnewest_rawfwimage_modules() (
 )
 
 download_rawfwimage_modules() (
+    REFER_NEWEST="${TEMP_DATA}/.newest-modules"
+    rm -f "${REFER_NEWEST}"
+
     cd "${DOWNLOADROOTFW_MODULES}" || \
     cd "${DEPLOYMENTROOTFW_MODULES}" || die "Can not use DOWNLOADROOTFW_MODULES='$DOWNLOADROOTFW_MODULES' nor DEPLOYMENTROOTFW_MODULES='$DEPLOYMENTROOTFW_MODULES'"
 
@@ -1408,7 +1474,9 @@ download_rawfwimage_modules() (
 
     # Try the filenames in local directories
     logmsg_info "Verifying if we have this checksum and corresponding file under original name in base dir..."
-    verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" && return 0
+    verify_threeway_checksum "${IMAGE_URL}" "${rIMAGE_URL_BASENAME}" "${rIMAGE_CSOLD}" "${aIMAGE_CSNEW}" \
+        && { echo "`pwd`/${rIMAGE_URL_BASENAME}" > "${REFER_NEWEST}" ;
+             return 0 ; }
 
     if [ -d "${DEPLOYMENTROOT_MODULES}" ] ; then
         # Do not remove deployed files!
@@ -1417,7 +1485,8 @@ download_rawfwimage_modules() (
             "${DEPLOYMENTROOT_MODULES}/${rIMAGE_URL_BASENAME}" \
             "${DEPLOYMENTROOT_MODULES}/${rIMAGE_CSOLD}" \
             "${aIMAGE_CSNEW}" \
-        && return 0
+        && { echo "${DEPLOYMENTROOT_MODULES}/${rIMAGE_URL_BASENAME}" > "${REFER_NEWEST}" ;
+             return 0 ; }
     fi
 
     if [ x"${CHECK_ONLY-}" = xyes ]; then
@@ -1472,14 +1541,23 @@ download_rawfwimage_modules() (
     logmsg_info "Got kernel modules archive OK:" && \
     ls -ld "${aTGT_FILE}" "${aIMAGE_CSOLD}" && \
     cat "${aIMAGE_CSOLD}" && \
-    return 42
+    { echo "${aTGT_FILE}" > "${REFER_NEWEST}" ;
+      return 42 ; }
 )
 
 removeold_rawfwimage_modules() (
-    cd "${DOWNLOADROOTFW_MODULES}" || die "Can not use DOWNLOADROOTFW_MODULES='$DOWNLOADROOTFW_MODULES'"
-    logmsg_info "NOTE: removeold_rawfwimage_modules() is likely a no-op at this point"
+    cd "${DOWNLOADROOTFW_MODULES}" || \
+    cd "${DEPLOYMENTROOTFW_MODULES}" || die "Can not use DOWNLOADROOTFW_MODULES='$DOWNLOADROOTFW_MODULES' nor DEPLOYMENTROOTFW_MODULES='$DEPLOYMENTROOTFW_MODULES'"
+    if [ -z "$DOWNLOADED_FW_MODULES" ] ; then
+        [ -s "${TEMP_DATA}/.newest-modules" ] \
+        && DOWNLOADED_FW_MODULES="`head -1 "${TEMP_DATA}/.newest-modules"`" \
+        && [ -n "$DOWNLOADED_FW_MODULES" ] && [ -s "$DOWNLOADED_FW_MODULES" ] \
+        || DOWNLOADED_FW_MODULES=""
+    fi
     VICTIMS=0
-    for F in `ls -1d *[0-9]*.*[0-9]*.${EXT} 2>/dev/null | head -n -1` ; do
+    for F in `ls -1d "${DOWNLOADROOTFW_MODULES}"/*[0-9]*.*[0-9]*.${EXT} "${DEPLOYMENTROOTFW_MODULES}"/*[0-9]*.*[0-9]*.${EXT} 2>/dev/null` ; do
+        [ -n "$DOWNLOADED_FW_MODULES" ] && [ -s "$DOWNLOADED_FW_MODULES" ] && [ "$DOWNLOADED_FW_MODULES" = "$F" ] && \
+            { logmsg_info "Keeping the just-downloaded modules archive: '$DOWNLOADED_FW_MODULES'" ; continue ; }
         logmsg_info "Removing older modules archive: '`pwd`/$F' and its checksum(s)"
         remove_image "$F"
         VICTIMS=$(($VICTIMS+1))
@@ -1504,6 +1582,36 @@ process_FACTORY_RESET_TTL_EXPIRED() {
 				"You can clear this warning with $0 --clear-failed-factory-reset"
 		fi
 	fi
+}
+
+# Discover recent download/check "best candidates" results
+# and populate corresponding variables
+learn_downloaded_images() {
+	[ -s "${TEMP_DATA}/.newest-osimage" ] && \
+		DOWNLOADED_OS_IMAGE="`head -1 "${TEMP_DATA}/.newest-osimage"`" && \
+		[ -n "$DOWNLOADED_OS_IMAGE" ] && [ -s "$DOWNLOADED_OS_IMAGE" ] || \
+		DOWNLOADED_OS_IMAGE=""
+	if [ -z "$DOWNLOADED_OS_IMAGE" ] ; then
+		[ -s "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ] && \
+		DOWNLOADED_OS_IMAGE="`head -1 "$DOWNLOADROOT_OSIMAGE/.newest-osimage"`" && \
+		[ -n "$DOWNLOADED_OS_IMAGE" ] && [ -s "$DOWNLOADED_OS_IMAGE" ] || \
+		DOWNLOADED_OS_IMAGE=""
+	fi
+
+	[ -s "${TEMP_DATA}/.newest-uboot" ] && \
+		DOWNLOADED_FW_UBOOT="`head -1 "${TEMP_DATA}/.newest-uboot"`" && \
+		[ -n "$DOWNLOADED_FW_UBOOT" ] && [ -s "$DOWNLOADED_FW_UBOOT" ] || \
+		DOWNLOADED_FW_UBOOT=""
+
+	[ -s "${TEMP_DATA}/.newest-uimage" ] && \
+		DOWNLOADED_FW_UIMAGE="`head -1 "${TEMP_DATA}/.newest-uimage"`" && \
+		[ -n "$DOWNLOADED_FW_UIMAGE" ] && [ -s "$DOWNLOADED_FW_UIMAGE" ] || \
+		DOWNLOADED_FW_UIMAGE=""
+
+	[ -s "${TEMP_DATA}/.newest-modules" ] && \
+		DOWNLOADED_FW_MODULES="`head -1 "${TEMP_DATA}/.newest-modules"`" && \
+		[ -n "$DOWNLOADED_FW_MODULES" ] && [ -s "$DOWNLOADED_FW_MODULES" ] || \
+		DOWNLOADED_FW_MODULES=""
 }
 
 ###########################################################################
@@ -1543,6 +1651,14 @@ esac
 ACTION_CHECK_OSIMAGE="no"
 ACTION_CHECK_FWIMAGE="no"
 
+# If any of these is "yes", and a corresponding image was downloaded during
+# this run (or validated as still up-to-date), touch its ".forceflash" file
+# after removing any existing ".forceflash" files for this category, if any.
+# No-op if nothing was downloaded/validated during this run for the category.
+ACTION_FORCEFLASH_OSIMAGE="no"
+ACTION_FORCEFLASH_FWIMAGE_UBOOT="no"
+ACTION_FORCEFLASH_FWIMAGE_UIMAGE="no"
+
 # The routines can force a specific URL rather than detecting the "newest" one
 [ -z "${URL_DOWNLOAD_OSIMAGE-}" ] &&                URL_DOWNLOAD_OSIMAGE=""
 [ -z "${URL_DOWNLOAD_FWIMAGE_RAW_UBOOT-}" ] &&      URL_DOWNLOAD_FWIMAGE_RAW_UBOOT=""
@@ -1558,8 +1674,14 @@ ACTION_REMOVEOLD_FWIMAGE="no"
 # Ultimate exit code of the script
 ACTION_RESULT=0
 
-# Exclude this (base) filename from removeold_osimage() hit-list
+# Exclude this (base) filename from removeold_*image() hit-list
+# since it was downloaded and/or tested OK during this run.
+# Also used to set forceflash flags, if requested.
 DOWNLOADED_OS_IMAGE=""
+DOWNLOADED_FW_UBOOT=""
+DOWNLOADED_FW_UIMAGE=""
+DOWNLOADED_FW_MODULES=""
+export DOWNLOADED_OS_IMAGE DOWNLOADED_FW_UBOOT DOWNLOADED_FW_UIMAGE DOWNLOADED_FW_MODULES
 
 # Note: /mnt/ext is in the list just in case rogue data is around.
 FACTORY_RESET_TTL_EXPIRED=""
@@ -1580,7 +1702,7 @@ TEMP_DATA="`mktemp -d /var/run/.update-rc3.$$.XXXXXX`" && [ -n "$TEMP_DATA" ] &&
 || { TEMP_DATA="/tmp/.update-rc3.$$" && rm -rf "${TEMP_DATA}" && mkdir -p "$TEMP_DATA" ; } \
 || die "Can not make a TEMP_DATA directory"
 export TEMP_DATA
-settraps "rm -rf '${TEMP_DATA}'" HUP INT QUIT TERM EXIT
+TRAP_SIGNALS="HUP INT QUIT TERM EXIT" settraps "rm -rf '${TEMP_DATA}'"
 
 while [ $# -gt 0 ]; do
 	case "${1-}" in
@@ -1681,6 +1803,24 @@ while [ $# -gt 0 ]; do
 		--erase-all)            FLAG_ERASE_ALL="yes" ;;
 		--touch-erase-all|--force-erase-all)
 		                        FLAG_ERASE_ALL="force" ;;
+		--forceflash-image|-FF)
+		                        ACTION_FORCEFLASH_OSIMAGE="yes"
+		                        ACTION_FORCEFLASH_FWIMAGE_UBOOT="yes"
+		                        ACTION_FORCEFLASH_FWIMAGE_UIMAGE="yes"
+		                        ;;
+		--forceflash-image-fw|--forceflash-image-FW|-FFf)
+		                        ACTION_FORCEFLASH_FWIMAGE_UBOOT="yes"
+		                        ACTION_FORCEFLASH_FWIMAGE_UIMAGE="yes"
+		                        ;;
+		--forceflash-image-os|--forceflash-image-OS|-FFo)
+		                        ACTION_FORCEFLASH_OSIMAGE="yes"
+		                        ;;
+		--forceflash-image-u-Boot|--forceflash-image-uBoot|--forceflash-image-uboot|--forceflash-image-u-boot|-FFb)
+		                        ACTION_FORCEFLASH_FWIMAGE_UBOOT="yes"
+		                        ;;
+		--forceflash-image-uImage|--forceflash-image-uimage|-FFi)
+		                        ACTION_FORCEFLASH_FWIMAGE_UIMAGE="yes"
+		                        ;;
 		--no-erase-all)         FLAG_ERASE_ALL="no" ;;
 		--reboot|-r)            WANT_REBOOT="yes" ;; # reboot if code 42 - got new files ok
 		-R)                     WANT_REBOOT="force" ;; # reboot if exitcode 0 or 42
@@ -1712,20 +1852,51 @@ done
 
 # Checks are special - after we do all which were requested (if any), we exit
 if [ x"$ACTION_CHECK_OSIMAGE" = xyes ] || [ x"$ACTION_CHECK_FWIMAGE" = xyes ]; then
-	RESULT_ACTION_CHECK_ANYIMAGE=0
+	RESULT_ACTION_CHECK_OSIMAGE=-1
+	RESULT_ACTION_CHECK_UBOOT=-1
+	RESULT_ACTION_CHECK_UIMAGE=-1
+	RESULT_ACTION_CHECK_MODULES=-1
+	RESULT_ACTION_CHECK_ANYIMAGE=-1
 	if [ x"$ACTION_CHECK_OSIMAGE" = xyes ]; then
-		CHECK_ONLY=yes download_osimage $URL_DOWNLOAD_OSIMAGE || RESULT_ACTION_CHECK_ANYIMAGE=$?
+		CHECK_ONLY=yes download_osimage $URL_DOWNLOAD_OSIMAGE; RESULT_ACTION_CHECK_OSIMAGE=$?
 	fi
 	if [ x"$ACTION_CHECK_FWIMAGE" = xyes ]; then
-		CHECK_ONLY=yes download_rawfwimage_uboot   $URL_DOWNLOAD_FWIMAGE_RAW_UBOOT   || RESULT_ACTION_CHECK_ANYIMAGE=$?
-		CHECK_ONLY=yes download_rawfwimage_uimage  $URL_DOWNLOAD_FWIMAGE_RAW_UIMAGE  || RESULT_ACTION_CHECK_ANYIMAGE=$?
-		CHECK_ONLY=yes download_rawfwimage_modules $URL_DOWNLOAD_FWIMAGE_RAW_MODULES || RESULT_ACTION_CHECK_ANYIMAGE=$?
+		CHECK_ONLY=yes download_rawfwimage_uboot   $URL_DOWNLOAD_FWIMAGE_RAW_UBOOT   ; RESULT_ACTION_CHECK_UBOOT=$?
+		CHECK_ONLY=yes download_rawfwimage_uimage  $URL_DOWNLOAD_FWIMAGE_RAW_UIMAGE  ; RESULT_ACTION_CHECK_UIMAGE=$?
+		CHECK_ONLY=yes download_rawfwimage_modules $URL_DOWNLOAD_FWIMAGE_RAW_MODULES ; RESULT_ACTION_CHECK_MODULES=$?
 	fi
+	learn_downloaded_images
+	for RES_STR in $RESULT_ACTION_CHECK_OSIMAGE $RESULT_ACTION_CHECK_UBOOT $RESULT_ACTION_CHECK_UIMAGE $RESULT_ACTION_CHECK_MODULES ; do
+		[ "$RES_STR" -gt "$RESULT_ACTION_CHECK_ANYIMAGE" ] && RESULT_ACTION_CHECK_ANYIMAGE="$RES_STR"
+	done
 	RES_STR="$RESULT_ACTION_CHECK_ANYIMAGE"
 	case "$RESULT_ACTION_CHECK_ANYIMAGE" in
-		0)  RES_STR="$RESULT_ACTION_CHECK_ANYIMAGE = Local files are OK, but there is nothing new to download" ;;
+		0)  RES_STR="$RESULT_ACTION_CHECK_ANYIMAGE = All checked local files are OK, but there is nothing new to download" ;;
 		42) RES_STR="$RESULT_ACTION_CHECK_ANYIMAGE = Should download something different from what we have locally" ;;
 	esac
+	if [ "$ACTION_FORCEFLASH_FWIMAGE_UBOOT" = yes  -a "$RESULT_ACTION_CHECK_UBOOT" = 0 ] ; then
+		logmsg_info "Adding a touch of u-Boot forceflash, as requested"
+		rm -f "${DEPLOYMENTROOTFW_UBOOT}/u-Boot.forceflash" "${DOWNLOADROOTFW_UBOOT}/u-Boot.forceflash"
+		case "${DOWNLOADED_FW_UBOOT}" in
+			/dev*) [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ] && removeold_rawfwimage_uboot ;;
+			*)
+				[ -n "${DOWNLOADED_FW_UBOOT}" ] && [ -s "${DOWNLOADED_FW_UBOOT}" ] && touch "${DOWNLOADED_FW_UBOOT}.forceflash" ;;
+		esac
+	fi
+	if [ "$ACTION_FORCEFLASH_FWIMAGE_UIMAGE" = yes -a "$RESULT_ACTION_CHECK_UIMAGE" = 0 ] ; then
+		logmsg_info "Adding a touch of uImage forceflash, as requested"
+		rm -f "${DEPLOYMENTROOTFW_UIMAGE}/uImage.forceflash" "${DOWNLOADROOTFW_UIMAGE}/uImage.forceflash"
+		case "${DOWNLOADED_FW_UIMAGE}" in
+			/dev*) [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ] && removeold_rawfwimage_uimage ;;
+			*)
+				[ -n "${DOWNLOADED_FW_UIMAGE}" ] && [ -s "${DOWNLOADED_FW_UIMAGE}" ] && touch "${DOWNLOADED_FW_UIMAGE}.forceflash" ;;
+		esac
+	fi
+	if [ "$ACTION_FORCEFLASH_OSIMAGE" = yes  -a "$RESULT_ACTION_CHECK_OSIMAGE" = 0 ] ; then
+		logmsg_info "Adding a touch of OS image forceflash, as requested"
+		rm -f "${DEPLOYMENTROOT_OSIMAGE}"/*.forceflash "${DOWNLOADROOT_OSIMAGE}"/*.forceflash
+		[ -n "${DOWNLOADED_OS_IMAGE}" ] && [ -s "${DOWNLOADED_OS_IMAGE}" ] && touch "${DOWNLOADED_OS_IMAGE}.forceflash"
+	fi
 	logmsg_info "Exiting after completion of requested --check-* operations ($RES_STR)"
 	exit $RESULT_ACTION_CHECK_ANYIMAGE
 fi
@@ -1765,6 +1936,30 @@ if [ "$ACTION_DOWNLOAD_FWIMAGE" = yes ]; then
 			logmsg_warn "New modules archive was not downloaded successfully, so old ones are not purged"
 			ACTION_REMOVEOLD_FWIMAGE=no_BadDownload
 		fi
+
+	learn_downloaded_images
+	if [ "$ACTION_FORCEFLASH_FWIMAGE_UBOOT" = yes ] && \
+	   [ "$RESULT_ACTION_DOWNLOAD_FWIMAGE_RAW_UBOOT" = 0 -o "$RESULT_ACTION_DOWNLOAD_FWIMAGE_RAW_UBOOT" = 42 ] \
+	; then
+		logmsg_info "Adding a touch of u-Boot forceflash, as requested"
+		rm -f "${DEPLOYMENTROOTFW_UBOOT}/u-Boot.forceflash" "${DOWNLOADROOTFW_UBOOT}/u-Boot.forceflash"
+		case "${DOWNLOADED_FW_UBOOT}" in
+			/dev*) [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ] && removeold_rawfwimage_uboot ;;
+			*)
+				[ -n "${DOWNLOADED_FW_UBOOT}" ] && [ -s "${DOWNLOADED_FW_UBOOT}" ] && touch "${DOWNLOADED_FW_UBOOT}.forceflash" ;;
+		esac
+	fi
+	if [ "$ACTION_FORCEFLASH_FWIMAGE_UIMAGE" = yes ] && \
+	   [ "$RESULT_ACTION_DOWNLOAD_FWIMAGE_RAW_UIMAGE" = 0 -o "$RESULT_ACTION_DOWNLOAD_FWIMAGE_RAW_UIMAGE" = 42 ] \
+	; then
+		logmsg_info "Adding a touch of uImage forceflash, as requested"
+		rm -f "${DEPLOYMENTROOTFW_UIMAGE}/uImage.forceflash" "${DOWNLOADROOTFW_UIMAGE}/uImage.forceflash"
+		case "${DOWNLOADED_FW_UIMAGE}" in
+			/dev*) [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ] && removeold_rawfwimage_uimage ;;
+			*)
+				[ -n "${DOWNLOADED_FW_UIMAGE}" ] && [ -s "${DOWNLOADED_FW_UIMAGE}" ] && touch "${DOWNLOADED_FW_UIMAGE}.forceflash" ;;
+		esac
+	fi
 fi
 
 if [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ]; then
@@ -1790,9 +1985,15 @@ if [ "$ACTION_DOWNLOAD_OSIMAGE" = yes ]; then
 			ACTION_REMOVEOLD_OSIMAGE=no_BadDownload
 		fi
 	else
-		[ -s "$DOWNLOADROOT_OSIMAGE/.newest-osimage" ] && \
-			DOWNLOADED_OS_IMAGE="`cat "$DOWNLOADROOT_OSIMAGE/.newest-osimage"`" || \
-			DOWNLOADED_OS_IMAGE=""
+		learn_downloaded_images
+	fi
+
+	if [ "$ACTION_FORCEFLASH_OSIMAGE" = yes ] && \
+	   [ "$RESULT_ACTION_DOWNLOAD_OSIMAGE" = 0 -o "$RESULT_ACTION_DOWNLOAD_OSIMAGE" = 42 ] \
+	; then
+		logmsg_info "Adding a touch of OS image forceflash, as requested"
+		rm -f "${DEPLOYMENTROOT_OSIMAGE}"/*.forceflash "${DOWNLOADROOT_OSIMAGE}"/*.forceflash
+		[ -n "${DOWNLOADED_OS_IMAGE}" ] && [ -s "${DOWNLOADED_OS_IMAGE}" ] && touch "${DOWNLOADED_OS_IMAGE}.forceflash"
 	fi
 fi
 

--- a/tools/update-rc3
+++ b/tools/update-rc3
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2015-2017 Eaton
+# Copyright (C) 2015-2018 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -793,7 +793,7 @@ download_osimage() (
     # land into the recovery location ("a"bsolute varnames)
     IMAGE_CSURL="${IMAGE_URL}.${IMAGE_CSALGO}"
     rIMAGE_CSOLD="${rIMAGE_URL_BASENAME_EXT}.${IMAGE_CSALGO}"
-    aIMAGE_CSNEW="/tmp/${rIMAGE_URL_BASENAME_EXT}.$$.${IMAGE_CSALGO}.tmp"
+    aIMAGE_CSNEW="${TEMP_DATA}/${rIMAGE_URL_BASENAME_EXT}.$$.${IMAGE_CSALGO}.tmp"
 
     # We rename the incoming image to include the type in flat directory space
     rTGT_FILE="${rIMAGE_URL_BASENAME_EXT}"
@@ -809,7 +809,7 @@ download_osimage() (
     esac
 
     rTGT_FILE_CSOLD="${rTGT_FILE}.${IMAGE_CSALGO}"
-    aTGT_FILE_CSNEW="/tmp/${rTGT_FILE}.$$.${IMAGE_CSALGO}.tmp"
+    aTGT_FILE_CSNEW="${TEMP_DATA}/${rTGT_FILE}.$$.${IMAGE_CSALGO}.tmp"
 
     trap 'TRAPCODE=$?; rm -f "$aTGT_FILE_CSNEW" "$aIMAGE_CSNEW"; exit $TRAPCODE' 0
 
@@ -1031,11 +1031,11 @@ download_rawfwimage_uboot() (
     # land into the recovery location ("a"bsolute varnames)
     IMAGE_CSURL="${IMAGE_URL}.${IMAGE_CSALGO}"
     rIMAGE_CSOLD="${rIMAGE_URL_BASENAME}.${IMAGE_CSALGO}"
-    aIMAGE_CSNEW="/tmp/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}.tmp"
+    aIMAGE_CSNEW="${TEMP_DATA}/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}.tmp"
 
     IMAGE_CSURL_PADDED="${IMAGE_URL}.${IMAGE_CSALGO}-padded"
     rIMAGE_CSOLD_PADDED="${rIMAGE_URL_BASENAME}.${IMAGE_CSALGO}-padded"
-    aIMAGE_CSNEW_PADDED="/tmp/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}-padded.tmp"
+    aIMAGE_CSNEW_PADDED="${TEMP_DATA}/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}-padded.tmp"
 
     trap 'TRAPCODE=$?; rm -f "${aIMAGE_CSNEW}" "${aIMAGE_CSNEW_PADDED}"; exit $TRAPCODE' 0
 
@@ -1199,11 +1199,11 @@ download_rawfwimage_uimage() (
     # land into the recovery location ("a"bsolute varnames)
     IMAGE_CSURL="${IMAGE_URL}.${IMAGE_CSALGO}"
     rIMAGE_CSOLD="${rIMAGE_URL_BASENAME}.${IMAGE_CSALGO}"
-    aIMAGE_CSNEW="/tmp/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}.tmp"
+    aIMAGE_CSNEW="${TEMP_DATA}/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}.tmp"
 
     IMAGE_CSURL_PADDED="${IMAGE_URL}.${IMAGE_CSALGO}-padded"
     rIMAGE_CSOLD_PADDED="${rIMAGE_URL_BASENAME}.${IMAGE_CSALGO}-padded"
-    aIMAGE_CSNEW_PADDED="/tmp/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}-padded.tmp"
+    aIMAGE_CSNEW_PADDED="${TEMP_DATA}/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}-padded.tmp"
 
     trap 'TRAPCODE=$?; rm -f "${aIMAGE_CSNEW}" "${aIMAGE_CSNEW_PADDED}"; exit $TRAPCODE' 0
 
@@ -1392,7 +1392,7 @@ download_rawfwimage_modules() (
     # land into the recovery location ("a"bsolute varnames)
     IMAGE_CSURL="${IMAGE_URL}.${IMAGE_CSALGO}"
     rIMAGE_CSOLD="${rIMAGE_URL_BASENAME}.${IMAGE_CSALGO}"
-    aIMAGE_CSNEW="/tmp/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}.tmp"
+    aIMAGE_CSNEW="${TEMP_DATA}/${rIMAGE_URL_BASENAME}.$$.${IMAGE_CSALGO}.tmp"
 
     trap 'TRAPCODE=$?; rm -f "$aIMAGE_CSNEW"; exit $TRAPCODE' 0
 
@@ -1573,6 +1573,14 @@ for F in \
         [ -f "$F.ttl-expired" ] && FACTORY_RESET_TTL_EXPIRED="`echo "$F.ttl-expired
 $FACTORY_RESET_TTL_EXPIRED" | sort | uniq`"
 done
+
+# Hold small recent downloads, reference files, etc.
+TEMP_DATA="`mktemp -d /var/run/.update-rc3.$$.XXXXXX`" && [ -n "$TEMP_DATA" ] && [ -d "$TEMP_DATA" ] \
+|| { TEMP_DATA="`mktemp -d /tmp/.update-rc3.$$.XXXXXX`" && [ -n "$TEMP_DATA" ] && [ -d "$TEMP_DATA" ] ; } \
+|| { TEMP_DATA="/tmp/.update-rc3.$$" && rm -rf "${TEMP_DATA}" && mkdir -p "$TEMP_DATA" ; } \
+|| die "Can not make a TEMP_DATA directory"
+export TEMP_DATA
+settraps "rm -rf '${TEMP_DATA}'" HUP INT QUIT TERM EXIT
 
 while [ $# -gt 0 ]; do
 	case "${1-}" in


### PR DESCRIPTION
FYI for most reviewers: now when you download an OS image which is not some straight-forward upgrade (same image type and release as before, just with a newer timestamp and maybe alphabetic order) - e.g. when you change image types with `-U`, downgrade, etc. - you can now use a `-FF` argument (or `-FFo` for specifically OS images) to have the script set the `.forceflash` flag for this image candidate, and it will be preferred over anything after reboot (if it passes sanity checks of course, and if the `uImage` active on the IPC also has the forceflash flag support -- yesterday's build or newer).

To clear all existing forceflash flags before checking or downloading images, you can run the script with `-NFF` argument.

For more details, see the updated help (`usage()`) and the code :)