### PR TITLE
Fixes for container-management scripts and "live factory reset"

### DIFF
--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -108,6 +108,7 @@ usage() {
 	echo "    wipe                 Alias to --stop-only"
 	echo "    update               Alias to --no-delete --no-install-dev --no-restore-saved"
 	echo "                         and disables user/group account sync from host to container"
+	echo "                         Allows to re-apply a modified overlay R/W to new RO OS image"
 	echo "    reboot               Alias to update with --no-download"
 	echo "    -h|--help            print this help"
 }
@@ -305,7 +306,8 @@ while [ $# -gt 0 ] ; do
 	reboot) # New uptime for existing rootfs - no initial reconfigs to do now
 		ATTEMPT_DOWNLOAD=no
 		;&
-	update) # New uptime for existing rootfs - no initial reconfigs to do now
+	update) # Download a new (overlay) existing rootfs but keep and reapply
+		# the locally modified data - so no initial reconfigs to do now
 		NO_DELETE=yes
 		NO_RESTORE_SAVED=yes
 		INSTALL_DEV_PKGS=no

--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -407,6 +407,15 @@ if [ -n "$VM" ] && [ -s "`pwd`/$VM.config-reset-vm" ]; then
 		logmsg_warn "Found configuration file for the '$VM', it will override the command-line settings:"
 		cat "`pwd`/$VM.config-reset-vm"
 		. "`pwd`/$VM.config-reset-vm" || die "Can not import config file '`pwd`/$VM.config-reset-vm'"
+		if [ "$NO_DELETE" = yes ]; then
+			logmsg_warn "For the no-delete mode (reboot), disabling options to reapply 'saved data' files, apply packages and copy user accounts from host"
+			NO_RESTORE_SAVED=yes
+			INSTALL_DEV_PKGS=no
+			FORCE_RUN_APT=""
+			COPYHOST_USERS=""
+			COPYHOST_GROUPS=""
+			ELEVATE_USERS=""
+		fi
 	else
 		logmsg_warn "Found configuration file for the '$VM', but it is ignored because ALLOW_CONFIG_FILE='$ALLOW_CONFIG_FILE'"
 	fi

--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2014-2016 Eaton
+# Copyright (C) 2014-2018 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1079,9 +1079,11 @@ if [ "$INSTALL_DEV_PKGS" = yes ]; then
 	; then
 		logmsg_info "Keeping /etc/resolv.conf in the VM from the 'saved' template"
 	else
-		logmsg_info "Restore /etc/resolv.conf in the VM to the default baseline"
-		grep "8.8.8.8" "${ALTROOT}/etc/resolv.conf.bak-devpkg" >/dev/null || \
-			cp -pf "${ALTROOT}/etc/resolv.conf.bak-devpkg" "${ALTROOT}/etc/resolv.conf"
+		if [ -f "${ALTROOT}/etc/resolv.conf.bak-devpkg" ] ; then
+			logmsg_info "Restore /etc/resolv.conf in the VM to the default baseline"
+			grep "8.8.8.8" "${ALTROOT}/etc/resolv.conf.bak-devpkg" >/dev/null || \
+				cp -pf "${ALTROOT}/etc/resolv.conf.bak-devpkg" "${ALTROOT}/etc/resolv.conf"
+		fi
 	fi
 
 	if [ -f "${ALTROOT}.saved/etc/nsswitch.conf" ] && \
@@ -1089,8 +1091,10 @@ if [ "$INSTALL_DEV_PKGS" = yes ]; then
 	; then
 		logmsg_info "Keeping /etc/nsswitch.conf in the VM from the 'saved' template"
 	else
-		logmsg_info "Restore /etc/nsswitch.conf in the VM to the default baseline"
-		cp -pf "${ALTROOT}/etc/nsswitch.conf.bak-devpkg" "${ALTROOT}/etc/nsswitch.conf"
+		if [ -f "${ALTROOT}/etc/nsswitch.conf.bak-devpkg" ] ; then
+			logmsg_info "Restore /etc/nsswitch.conf in the VM to the default baseline"
+			cp -pf "${ALTROOT}/etc/nsswitch.conf.bak-devpkg" "${ALTROOT}/etc/nsswitch.conf"
+		fi
 	fi
 
 #	logmsg_info "Restart networking in the VM chroot to refresh virtual network settings"

--- a/tests/CI/ci-setup-test-machine.sh
+++ b/tests/CI/ci-setup-test-machine.sh
@@ -105,7 +105,8 @@ http_get() {
 update_pkg_keys() {
     echo "INFO: Updating our OBS packaging keys..."
     # TODO: check if OS is debian... though this applies to all the APT magic
-    http_get http://obs.roz53.lab.etn.com:82/Pool:/master/Debian_8.0/Release.key | apt-key add -
+    http_get http://obs.roz.lab.etn.com:82/Pool:/master/Debian_8.0/Release.key | apt-key add -
+    # http_get http://obs.roz53.lab.etn.com:82/Pool:/master/Debian_8.0/Release.key | apt-key add -
     # http_get http://obs.mbt.lab.etn.com:82/Pool:/master/Debian_8.0/Release.key | apt-key add -
 
     echo "INFO: Updating upstream-distro packaging keys..."

--- a/tests/CI/ci-setup-test-machine.sh
+++ b/tests/CI/ci-setup-test-machine.sh
@@ -172,6 +172,8 @@ restore_ssh_service() {
 
 update_system() {
     if [[ -n "${FORCE_RUN_APT}" ]]; then
+        # Die on failures, so callers know that VM setup did not go as planned
+        set -e
         limit_packages_expiration_check
         update_pkg_keys
         update_pkg_metadata
@@ -185,6 +187,9 @@ update_system() {
     else
         echo "SKIPPED: $0 update_system() : this action is not default anymore, and FORCE_RUN_APT is not set and exported by caller" >&2
     fi
+
+    # Here an exit-code suffices
+    set +e
     restore_ssh_service
 }
 

--- a/tests/CI/ci-setup-test-machine.sh
+++ b/tests/CI/ci-setup-test-machine.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2014-2016 Eaton
+# Copyright (C) 2014-2018 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -40,6 +40,13 @@ limit_packages_recommends() {
     mkdir -p /etc/apt/apt.conf.d
     echo 'APT::Install-Recommends "false";' > \
        "/etc/apt/apt.conf.d/02no-recommends"
+}
+
+limit_packages_expiration_check() {
+    echo "INFO: Tell APT to not ignore repositories that were not updated recently"
+    mkdir -p /etc/apt/apt.conf.d
+    echo 'Acquire::Check-Valid-Until "false";' > \
+       "/etc/apt/apt.conf.d/02no-expiration"
 }
 
 limit_packages_paths() {
@@ -165,6 +172,7 @@ restore_ssh_service() {
 
 update_system() {
     if [[ -n "${FORCE_RUN_APT}" ]]; then
+        limit_packages_expiration_check
         update_pkg_keys
         update_pkg_metadata
         limit_packages_recommends

--- a/tests/CI/jenkins-reset-virtuals.groovy
+++ b/tests/CI/jenkins-reset-virtuals.groovy
@@ -38,7 +38,7 @@ def waitForJob(name) {
 }
 
 // Start another jobs to reset machines
-for( vm in ["mirabox-test.roz53.lab.etn.com", "debian-test.roz53.lab.etn.com", "test-debian-0", "test-debian-1", "test-debian-2", "test-debian-3"]) {
+for( vm in ["mirabox-test.roz.lab.etn.com", "debian-test.roz.lab.etn.com", "test-debian-0", "test-debian-1", "test-debian-2", "test-debian-3"]) {
     println "reseting $vm";
     startJob(
         "reset_virtual_machine",

--- a/tests/CI/resetdb-bios-rc-demo.sh
+++ b/tests/CI/resetdb-bios-rc-demo.sh
@@ -24,7 +24,7 @@
 #           Used for internal testing.
 
 REFHOST="bios-rc-demo"
-REFFQDN="$REFHOST.roz53.lab.etn.com"
+REFFQDN="$REFHOST.roz.lab.etn.com"
 TMPFILE="/tmp/mysqldump-rc-demo.sql.gz"
 DATABASE="box_utf8"
 

--- a/tests/CI/update_demo
+++ b/tests/CI/update_demo
@@ -29,7 +29,7 @@
 
 PATH="/bin:/usr/bin:/sbin:/usr/sbin"
 
-OBS_IMAGES_SERVER="http://obs.roz53.lab.etn.com"
+OBS_IMAGES_SERVER="http://obs.roz.lab.etn.com"
 OBS_IMAGES_BASEURL="$OBS_IMAGES_SERVER/images"
 ARCH="x86_64"
 PEMFILE_DIR="/root/pems"
@@ -95,20 +95,20 @@ setup_bios_demo() (
     # copy resolv.conf (demo has not OBS default, but ROZ LAB one)
     #
     cp -f /etc/resolv.conf ./etc/
-    echo bios-demo.roz53.lab.etn.com > ./etc/hostname
+    echo bios-demo.roz.lab.etn.com > ./etc/hostname
 
-    if [ -n "`ssh -p 4222 root@bios-rc-demo.roz53.lab.etn.com echo ahoj`" ] ; then
+    if [ -n "`ssh -p 4222 root@bios-rc-demo.roz.lab.etn.com echo ahoj`" ] ; then
         #
         # replicate NUT config from bios-rc-demo
         #
         echo "Exporting a copy of NUT configs from bios-rc-demo..."
-        scp -P 4222 root@bios-rc-demo.roz53.lab.etn.com:/etc/nut/* ./etc/nut
+        scp -P 4222 root@bios-rc-demo.roz.lab.etn.com:/etc/nut/* ./etc/nut
 
         #
         # Dump database from bios-rc-demo
         #
         echo "Exporting a copy of database content from bios-rc-demo..."
-        ssh -p 4222 root@bios-rc-demo.roz53.lab.etn.com mysqldump -u root box_utf8 > ./mysqldump || rm -f ./mysqldump
+        ssh -p 4222 root@bios-rc-demo.roz.lab.etn.com mysqldump -u root box_utf8 > ./mysqldump || rm -f ./mysqldump
     fi
 
     #
@@ -117,9 +117,9 @@ setup_bios_demo() (
     cat << EOF | chroot . /bin/bash
 /usr/lib/mysql/rcmysql start
 echo 'Importing default database schema...'
-wget -O - "http://tomcat.roz53.lab.etn.com/git-web/?p=core.git;a=blob_plain;f=database/mysql/initdb.sql;hb=HEAD" |  mysql -u root
-# wget -O - "http://tomcat.roz53.lab.etn.com/git-web/?p=core.git;a=blob_plain;f=database/mysql/load_data.sql;hb=HEAD" | mysql -u root box_utf8
-# wget -O - "http://tomcat.roz53.lab.etn.com/git-web/?p=core.git;a=blob_plain;f=database/mysql/load_ROZLAB.sql;hb=HEAD" | mysql -u root box_utf8
+wget -O - "http://tomcat.roz.lab.etn.com/git-web/?p=core.git;a=blob_plain;f=database/mysql/initdb.sql;hb=HEAD" |  mysql -u root
+# wget -O - "http://tomcat.roz.lab.etn.com/git-web/?p=core.git;a=blob_plain;f=database/mysql/load_data.sql;hb=HEAD" | mysql -u root box_utf8
+# wget -O - "http://tomcat.roz.lab.etn.com/git-web/?p=core.git;a=blob_plain;f=database/mysql/load_ROZLAB.sql;hb=HEAD" | mysql -u root box_utf8
 [ -s /mysqldump ] && echo 'Importing /mysqldump...' && mysql -u root box_utf8 < /mysqldump
 /usr/lib/mysql/rcmysql stop
 EOF


### PR DESCRIPTION
* Better support recent "no-delete" mode (update/reboot) with "devel" image containers
* Fail package customization script upon packaging system errors, to propagate issues to the caller
* In factory-reset-live, try more ways to reset user password to the simple default