### PR TITLE
Further fixes for container-management scripts and "live factory reset"

### DIFF
--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -1212,6 +1212,9 @@ if [ -n "${GEN_REL_DETAILS}" -a -s "${GEN_REL_DETAILS}" -a -x "${GEN_REL_DETAILS
 	export FW_UIMAGEPART_CSDEVPAD  FW_UIMAGEPART_SIZE
 	export HWD_CATALOG_NB  HWD_REV HWD_SERIAL_NB
 
+	# Provide a default if caller did not DEFINE one
+	[[ ! -v "$HWD_CATALOG_NB" ]] && HWD_CATALOG_NB="IPC3000E-LXC"
+
 	logmsg_info "Generating the release details file(s) with the ${GEN_REL_DETAILS} script in OS image"
 	"${GEN_REL_DETAILS}"
 ) ; fi

--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -89,6 +89,7 @@ usage() {
 	echo "    --install-dev        run ci-setup-test-machine.sh (if available) to install packages"
 	echo "    --with-java8-jre     when setting up packages with ci-setup-test-machine.sh, set"
 	echo "                         DEPLOY_JAVA8=yes to install a Java8 JRE for certain uses"
+	echo "    --with-libzmq4-dev   explicitly install libzmq4-dev here (if install-dev)"
 	echo "    --no-install-dev     do not run ci-setup-test-machine.sh, even on IMGTYPE=devel"
 	echo "    --no-restore-saved   do not copy stashed custom configs from a VMNAME.saved/ dir"
 	echo "    --no-overlayfs       enforce use of tarballs, even if overlayfs is supported by host"
@@ -243,6 +244,7 @@ DOTDOMAINNAME=""
 [ -z "${NO_RESTORE_SAVED-}" ] && NO_RESTORE_SAVED=no
 [ -z "${NO_DELETE-}" ] && NO_DELETE=no
 [ -z "${DEPLOY_JAVA8-}" ] && DEPLOY_JAVA8=no
+[ -z "${DEPLOY_LIBZMQ4_DEV-}" ] && DEPLOY_LIBZMQ4_DEV=no
 [ -z "${ADDUSER_ABUILD-}" ] && ADDUSER_ABUILD=no
 
 while [ $# -gt 0 ] ; do
@@ -358,6 +360,9 @@ while [ $# -gt 0 ] ; do
 	--with-java8-jre) # Only works if INSTALL_DEV_PKGS=yes
 		shift
 		DEPLOY_JAVA8=yes ; export DEPLOY_JAVA8 ;;
+	--with-libzmq4-dev) # Likewise
+		shift
+		DEPLOY_LIBZMQ4_DEV=yes ; export DEPLOY_LIBZMQ4_DEV ;;
 	--add-user=abuild) ADDUSER_ABUILD=yes ; shift ;;
 	--copy-host-users)
 		COPYHOST_USERS="$2"; shift 2;;

--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -1104,11 +1104,12 @@ if [ "$INSTALL_DEV_PKGS" = yes ]; then
 fi
 
 if [ -z "${GEN_REL_DETAILS-}" ] ; then
-    GEN_REL_DETAILS=""
-    for F in "${ALTROOT}/usr/share/fty/scripts/generate-release-details.sh" \
-        "${ALTROOT}/usr/share/bios/scripts/generate-release-details.sh" ; do
-            [ -s "$F" ] && [ -x "$F" ] && GEN_REL_DETAILS="$F" && break
-    done
+	GEN_REL_DETAILS=""
+	for F in "${ALTROOT}/usr/share/fty/scripts/generate-release-details.sh" \
+		"${ALTROOT}/usr/share/bios/scripts/generate-release-details.sh" \
+	; do
+		[ -s "$F" ] && [ -x "$F" ] && GEN_REL_DETAILS="$F" && break
+	done
 fi
 
 if [ -n "${GEN_REL_DETAILS}" -a -s "${GEN_REL_DETAILS}" -a -x "${GEN_REL_DETAILS}" \

--- a/tests/CI/ci-reset-virtual-machine.sh
+++ b/tests/CI/ci-reset-virtual-machine.sh
@@ -87,6 +87,8 @@ usage() {
 	echo "    -hp|--http-proxy URL the http_proxy override to access OBS ('$http_proxy')"
 	echo "    -ap|--apt-proxy URL  the http_proxy to access external APT images ('$APT_PROXY')"
 	echo "    --install-dev        run ci-setup-test-machine.sh (if available) to install packages"
+	echo "    --with-java8-jre     when setting up packages with ci-setup-test-machine.sh, set"
+	echo "                         DEPLOY_JAVA8=yes to install a Java8 JRE for certain uses"
 	echo "    --no-install-dev     do not run ci-setup-test-machine.sh, even on IMGTYPE=devel"
 	echo "    --no-restore-saved   do not copy stashed custom configs from a VMNAME.saved/ dir"
 	echo "    --no-overlayfs       enforce use of tarballs, even if overlayfs is supported by host"
@@ -239,6 +241,7 @@ DOTDOMAINNAME=""
 [ -z "${OVERLAYFS-}" ] && OVERLAYFS="auto"
 [ -z "${NO_RESTORE_SAVED-}" ] && NO_RESTORE_SAVED=no
 [ -z "${NO_DELETE-}" ] && NO_DELETE=no
+[ -z "${DEPLOY_JAVA8-}" ] && DEPLOY_JAVA8=no
 
 while [ $# -gt 0 ] ; do
 	case "$1" in
@@ -349,6 +352,9 @@ while [ $# -gt 0 ] ; do
 		export FORCE_RUN_APT
 		shift
 		;;
+	--with-java8-jre) # Only works if INSTALL_DEV_PKGS=yes
+		shift
+		DEPLOY_JAVA8=yes ; export DEPLOY_JAVA8 ;;
 	--copy-host-users)
 		COPYHOST_USERS="$2"; shift 2;;
 	--copy-host-groups)
@@ -394,6 +400,7 @@ fi
 [ x"$http_proxy" = x- ] && http_proxy="" && export http_proxy
 
 [ -z "$ARCH" ] && ARCH="`uname -m`"
+export ARCH
 # Note: several hardcoded paths are expected relative to "snapshots", so
 # it is critical that we succeed changing into this directory in the end.
 

--- a/tests/CI/ci-setup-test-machine.sh
+++ b/tests/CI/ci-setup-test-machine.sh
@@ -180,10 +180,10 @@ update_system() {
         update_pkg_metadata
         limit_packages_recommends
         limit_packages_paths
-        install_packages_missing
+        install_packages_missing || install_packages_missing
         limit_packages_docs
-        install_package_set_dev
-        install_package_set_biosdeps
+        install_package_set_dev || install_package_set_dev
+        install_package_set_biosdeps || install_package_set_biosdeps
         limit_packages_forceremove
     else
         echo "SKIPPED: $0 update_system() : this action is not default anymore, and FORCE_RUN_APT is not set and exported by caller" >&2

--- a/tests/CI/ci-setup-test-machine.sh
+++ b/tests/CI/ci-setup-test-machine.sh
@@ -174,17 +174,16 @@ restore_ssh_service() {
 update_system() {
     if [[ -n "${FORCE_RUN_APT}" ]]; then
         # Die on failures, so callers know that VM setup did not go as planned
-        set -e
-        limit_packages_expiration_check
-        update_pkg_keys
-        update_pkg_metadata
-        limit_packages_recommends
-        limit_packages_paths
-        install_packages_missing || install_packages_missing
-        limit_packages_docs
-        install_package_set_dev || install_package_set_dev
-        install_package_set_biosdeps || install_package_set_biosdeps
-        limit_packages_forceremove
+        limit_packages_expiration_check || die "Failed to limit_packages_expiration_check()"
+        update_pkg_keys || die "Failed to update_pkg_keys()"
+        update_pkg_metadata || die "Failed to update_pkg_metadata()"
+        limit_packages_recommends || die "Failed to limit_packages_recommends()"
+        limit_packages_paths || die "Failed to limit_packages_paths()"
+        install_packages_missing || install_packages_missing || die "Failed to install_packages_missing()"
+        limit_packages_docs || die "Failed to limit_packages_docs()"
+        install_package_set_dev || install_package_set_dev || die "Failed to install_package_set_dev()"
+        install_package_set_biosdeps || install_package_set_biosdeps || die "Failed to install_package_set_biosdeps()"
+        limit_packages_forceremove || die "Failed to limit_packages_forceremove()"
     else
         echo "SKIPPED: $0 update_system() : this action is not default anymore, and FORCE_RUN_APT is not set and exported by caller" >&2
     fi

--- a/tests/CI/ci-setup-test-machine.sh
+++ b/tests/CI/ci-setup-test-machine.sh
@@ -176,6 +176,15 @@ install_package_set_java8_jre() {
     fi
 }
 
+install_package_set_libzmq4_dev() {
+    # Needed for builds against specifically upstream libzmq, not our default fork
+    # Magic variable can be set and exported by caller
+    if [ -n "${DEPLOY_LIBZMQ4_DEV-}" ] && [ "${DEPLOY_LIBZMQ4_DEV-}" != no ]; then
+        echo "INFO: Installing the upstream libzmq4-dev, not our default fork..."
+        yes | apt-get install -y --force-yes libzmq4-dev
+    fi
+}
+
 restore_ssh_service() {
     /bin/systemctl stop ssh.socket
     /bin/systemctl mask ssh.socket
@@ -206,6 +215,7 @@ update_system() {
         install_package_set_dev || install_package_set_dev || die "Failed to install_package_set_dev()"
         install_package_set_biosdeps || install_package_set_biosdeps || die "Failed to install_package_set_biosdeps()"
         install_package_set_java8_jre || install_package_set_java8_jre || die "Failed to install_package_set_java8_jre()"
+        install_package_set_libzmq4_dev || install_package_set_libzmq4_dev || die "Failed to install_package_set_libzmq4_dev()"
         limit_packages_forceremove || die "Failed to limit_packages_forceremove()"
     else
         echo "SKIPPED: $0 update_system() : this action is not default anymore, and FORCE_RUN_APT is not set and exported by caller" >&2

--- a/tools/factory-reset-live.sh.in
+++ b/tools/factory-reset-live.sh.in
@@ -121,7 +121,8 @@ do_undatabase() {
     logmsg_info "Stopping database engine..."
     systemctl stop fty-db-engine.service || die "Can not ensure database is stopped"
     logmsg_info "Clearing database-related files..."
-    rm -rf /var/lib/mysql /var/lib/fty/sql/mysql/* /etc/default/bios-db-r[ow] /root/.my.cnf
+    rm -rf /var/lib/mysql /var/lib/fty/sql/mysql/* /var/lib/fty/sql/mysql/.*.cnf* \
+        /etc/default/bios-db-r[ow] /root/.my.cnf
     if [ "$ENABLESVC" = yes ]; then
         logmsg_info "Starting database engine, if possible..."
         systemctl restart fty-db-engine.service || true # License may forbid startup

--- a/tools/factory-reset-live.sh.in
+++ b/tools/factory-reset-live.sh.in
@@ -72,9 +72,14 @@ if [[ $(id -u) != 0 ]]; then
     die "This script is not intended for ordinary usage by non-root users"
 fi
 
-if [[ ! -s /etc/release-details.json ]] ; then
+if [[ ! -f /etc/release-details.json ]] ; then
     # Sanity check to not destroy a developer workstation etc. ;)
     die "An /etc/release-details.json file was not found - be sure to run in IPM system!"
+fi
+
+if [[ ! -s /etc/release-details.json ]] ; then
+    # If the caller just "touched" the file, make it a valid JSON
+    echo '{}' > /etc/release-details.json
 fi
 
 do_reset_passwd() {

--- a/tools/factory-reset-live.sh.in
+++ b/tools/factory-reset-live.sh.in
@@ -41,6 +41,11 @@ logmsg_info() {
     return 0
 }
 
+error() {
+    echo "ERROR: `date -u`: $*"
+    return 1
+}
+
 usage() {
     cat << EOF
 $0: Automation of in-vivo factory-reset effect for
@@ -85,7 +90,15 @@ fi
 do_reset_passwd() {
     # TODO: On real RC, copy default password hash from /mnt/root-ro/etc/shadow?
     logmsg_info "Resetting admin password to our very simple default value..."
-    yes "admin" | passwd admin
+    yes "admin" | passwd admin && return
+    for INITACCT in /usr/share/{fty,bios}/scripts/init-os-accounts.sh ; do
+        if [[ -x "$INITACCT" ]] ; then
+            usermod --password "`USER_PASS='admin' "$INITACCT" hashPasswd`" admin && return
+            break
+        fi
+    done
+    logmsg_error "Failed to reset the admin password to our very simple default value"
+    return 1
 }
 
 do_unlicense() {

--- a/tools/factory-reset-live.sh.in
+++ b/tools/factory-reset-live.sh.in
@@ -88,8 +88,13 @@ if [[ ! -s /etc/release-details.json ]] ; then
 fi
 
 do_reset_passwd() {
-    # TODO: On real RC, copy default password hash from /mnt/root-ro/etc/shadow?
     logmsg_info "Resetting admin password to our very simple default value..."
+    if [ -s /mnt/root-ro/etc/shadow ]; then
+        OLDPASS="`egrep '^admin:' /mnt/root-ro/etc/shadow | awk -F: '{print $2}'`" || OLDPASS=""
+        if [ -n "$OLDPASS" ] ; then
+            usermod --password "$OLDPASS" admin && return
+        fi
+    fi
     yes "admin" | passwd admin && return
     for INITACCT in /usr/share/{fty,bios}/scripts/init-os-accounts.sh ; do
         if [[ -x "$INITACCT" ]] ; then

--- a/tools/factory-reset-live.sh.in
+++ b/tools/factory-reset-live.sh.in
@@ -159,6 +159,12 @@ do_unnut() {
     systemctl stop nut-server || true
     systemctl stop nut-driver.target || true
 
+    # Note: This requires our systemctl wrapper
+    for D in `systemctl list-ipm-units 'nut-driver@.+\.service'` ; do
+        systemctl stop "$D" || true
+        systemctl disable "$D" || true
+    done
+
     logmsg_info "Resetting NUT monitored device configs..."
     echo "maxretry = 3" > /etc/nut/ups.conf
 


### PR DESCRIPTION
* factory-reset-live can do a better job resetting NUT, DB and Password aspects
* container management failure-handling revised; automate preinstallation of Java if requested (for Jenkins agents, CLI tools of some 3rd-party projects), libzmq4-dev (to explicitly build e.g. malamute), and better cooperate with Jenkins as its agent - largely to eventually supplant the less featured (and insufficient for current needs) script used in CI to deploy build agents, as well as to have equivalent features on developer workstations already