### PR TITLE
preinstallimage-bios.sh: Do not remove shared libraries

### DIFF
--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -330,7 +330,7 @@ EOF
 
 # Uninstall various packages that are not needed
 # Note: We restore "/bin/diff" and "/bin/*grep" via busybox, below
-for i in $(dpkg -l | awk '/perl/{ print $2; }') apt fakeroot ncurses-bin diffutils grep sysvinit ncurses-common libicu52 lsb-release; do
+for i in $(dpkg -l | awk '/perl/{ print $2; }') apt fakeroot ncurses-bin diffutils grep sysvinit ncurses-common lsb-release; do
     case "$IMGTYPE" in
         *devel*)
             echo dpkg -P --force-all $i


### PR DESCRIPTION
Removing libicu52 breaks open-vm-tools in the OVA:

$ vmtoolsd --help
vmtoolsd: error while loading shared libraries: libicui18n.so.52: cannot
open shared object file: No such file or directory