### PR TITLE
Problem: systemd strikes again

### DIFF
--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#   Copyright (c) 2014-2017 Eaton
+#   Copyright (c) 2014-2018 Eaton
 #
 #   This file is part of the Eaton 42ity project.
 #

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -497,7 +497,8 @@ for unit in $(/bin/systemctl list-unit-files | egrep '^(fty|etn|ipc|ipm|ova)-*' 
     ### Also note we do not skip these units, because they may be our product's
     ### ways to manage a unit distributed with some naming pattern not matched
     ### above.
-    unit_realname="$(/bin/systemctl show -p Id "${unit}" | sed 's,^Id=,,')" || unit_realname="${unit}"
+    unit_realname="$(/bin/systemctl show -p Id "${unit}" | sed 's,^Id=,,')" \
+        && [ -n "${unit_realname}" ] || unit_realname="${unit}"
     /bin/systemctl enable ${unit_realname}
 done
 

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -490,8 +490,15 @@ fi
 # Generally enable everything fty-* (and related)
 # Note: we do not unmask here, because if anyone went through the
 # non-default trouble of masking, it must have had a reason :)
-for unit in $(systemctl list-unit-files | egrep '^(fty|etn|ipc|ipm)-*' | cut -d ' ' -f 1); do
-    /bin/systemctl enable ${unit}
+for unit in $(/bin/systemctl list-unit-files | egrep '^(fty|etn|ipc|ipm)-*' | cut -d ' ' -f 1); do
+    ### Note: some units declare Alias= names to be called by
+    ### These names are returned among "systemctl list-unit-files" but since
+    ### there are no actual files by that name, they can not be enabled!
+    ### Also note we do not skip these units, because they may be our product's
+    ### ways to manage a unit distributed with some naming pattern not matched
+    ### above.
+    unit_realname="$(/bin/systemctl show -p Id "${unit}" | sed 's,^Id=,,')" || unit_realname="${unit}"
+    /bin/systemctl enable ${unit_realname}
 done
 
 # Enable REST API via tntnet

--- a/obs/preinstallimage-bios.sh
+++ b/obs/preinstallimage-bios.sh
@@ -490,7 +490,7 @@ fi
 # Generally enable everything fty-* (and related)
 # Note: we do not unmask here, because if anyone went through the
 # non-default trouble of masking, it must have had a reason :)
-for unit in $(/bin/systemctl list-unit-files | egrep '^(fty|etn|ipc|ipm)-*' | cut -d ' ' -f 1); do
+for unit in $(/bin/systemctl list-unit-files | egrep '^(fty|etn|ipc|ipm|ova)-*' | cut -d ' ' -f 1); do
     ### Note: some units declare Alias= names to be called by
     ### These names are returned among "systemctl list-unit-files" but since
     ### there are no actual files by that name, they can not be enabled!

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -1,7 +1,7 @@
 #!/bin/bash
 # WARNING: bash syntax and capabilities are used intensively in code below!
 #
-# Copyright (C) 2015-2017 Eaton
+# Copyright (C) 2015-2018 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -97,11 +97,13 @@ SYSTEMCTL_UNITS_COMMON="$SYSTEMCTL_UNITS_COMMON_EXTERNAL $SYSTEMCTL_UNITS_COMMON
 SYSTEMCTL_UNITS_REGEX_EXTERNAL_LIST='nut-driver'
 SYSTEMCTL_UNITS_REGEX_INTERNAL_LIST='composite-metrics|fty-metric-composite'
 SYSTEMCTL_UNITS_REGEX_EXTERNAL="($SYSTEMCTL_UNITS_REGEX_EXTERNAL_LIST)"'@[^[:blank:]]*'
-SYSTEMCTL_UNITS_REGEX_INTERNAL="($SYSTEMCTL_UNITS_REGEX_INTERNAL_LIST)"'@[^[:blank:]]*|etn-[^[:blank:]]*'
+# Add vendor added-value units; note that ipc-* units that are
+# intended for physical appliance are listed above explicitly
+SYSTEMCTL_UNITS_REGEX_INTERNAL="($SYSTEMCTL_UNITS_REGEX_INTERNAL_LIST)"'@[^[:blank:]]*|(etn|ipm|ova)-[^[:blank:]]*'
 SYSTEMCTL_UNITS_REGEX="($SYSTEMCTL_UNITS_REGEX_EXTERNAL_LIST|$SYSTEMCTL_UNITS_REGEX_INTERNAL_LIST)"'@[^[:blank:]]*'
 # SAME data for "case" matching of multi-instance services
 SYSTEMCTL_UNITS_GLOBS_EXTERNAL='nut-driver@*'
-SYSTEMCTL_UNITS_GLOBS_INTERNAL='composite-metrics@* etn-*'
+SYSTEMCTL_UNITS_GLOBS_INTERNAL='composite-metrics@* etn-* ipm-* ova-*'
 SYSTEMCTL_UNITS_GLOBS="$SYSTEMCTL_UNITS_GLOBS_EXTERNAL $SYSTEMCTL_UNITS_GLOBS_INTERNAL"
 
 # Note: The matching code seems a bit overcomplicated, but it evolved


### PR DESCRIPTION
Follows up on fallout from #217 "Problem: etn/ipm/ipc services not autoenabled"

Who thought that it is a good idea - returning in `systemctl list-unit-files` (*files* Carl!) a unit's alias that has no corresponding same-named file and so can not be `enable`d? ;)