### PR TITLE
Preinstall: Running in chroot, ignoring request

### DIFF
--- a/tools/systemctl
+++ b/tools/systemctl
@@ -1192,7 +1192,7 @@ process_CLI_systemctl() {
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 help|-h|-help|--help) usage; exit 1 ;;
-                --all|-a|--full|-l|--quiet)
+                --all|-a|--full|-l|--quiet|--now|--runtime)
                     SYSTEMCTL_ARGS="$SYSTEMCTL_ARGS $1" ;;
                 --no-block)
                     # NOTE: Avoid early kills inside a dependency loop too


### PR DESCRIPTION
After all the magical neat error handling in PRs #217 and #219, we see this during build:

````
[  306s] + for unit in '$(/bin/systemctl list-unit-files | egrep '\''^(fty|etn|ipc|ipm|ova)-*'\'' | cut -d '\'' '\'' -f 1)'
[  306s] ++ /bin/systemctl show -p Id ipc-lcd-engine.service
[  306s] ++ sed 's,^Id=,,'
[  306s] Running in chroot, ignoring request.
[  306s] + unit_realname=
[  306s] + '[' -n '' ']'
[  306s] + unit_realname=ipc-lcd-engine.service
[  306s] + /bin/systemctl enable ipc-lcd-engine.service
[  306s] Operation failed: No such file or directory
[  306s] + exit 1
````