### PR TITLE
Problem: pam_authenticate API is failing

### DIFF
--- a/docs/examples/pam.d/fty
+++ b/docs/examples/pam.d/fty
@@ -22,7 +22,6 @@
 
     auth	required        pam_env.so
     auth	include         fty-auth
-    auth	required        pam_unix.so	try_first_pass
 
 # Note that "requisite" mismatch fails instantly,
 # while "required" goes on to other checks first


### PR DESCRIPTION
Problem : with "auth   required        pam_unix.so try_first_pass", pam_authenticate() API function failed.
Note with or without "auth   required        pam_unix.so try_first_pass" SASL demon is still working.
BTW, what was the intention to have try_first_pass argument directive at this level, just after pam_env (I mean) ? I'm have some doubts about the efficiency of it.
Solution : so remove it. 

Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>