### PR TITLE
Problem: Service fty-license-accepted has to notify etn-licensing abo…

### DIFF
--- a/systemd/fty-license-accepted.service
+++ b/systemd/fty-license-accepted.service
@@ -21,6 +21,7 @@ User=root
 ExecStartPre=/bin/dash -c "sleep 2 ; /usr/bin/test -s /var/lib/fty/license"
 ExecStart=/bin/dash -c "while ! /usr/bin/test -s /var/lib/fty/license ; do sleep 3 ; done"
 ExecStartPost=-/bin/systemctl start --no-block bios.service
+ExecStartPost=/bin/dash -c "/usr/bin/bmsg publish eula ACCEPTED"
 ExecStartPost=/bin/dash -c "/bin/systemctl start --no-block -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundBy fty-license-accepted.service | cut -d= -f2 | sort | uniq | tr '\n' ' ')"
 
 [Install]


### PR DESCRIPTION
…ut EULA acceptance via Malamute.

Solution: Use 'bmsg publish eula ACCEPTED' for that.
*********************************************************************
Size: XS
Impact: M
Please wait until #38 in fty-proto is merged.

Signed-off-by: Jana Rapava <janarapava@eaton.com>