### PR TITLE
Problem: no place for a proxy settings file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -302,6 +302,7 @@ SYSTEMD_UNITS_LOWLEVEL += \
 # service instances for us. TODO: should tntnet@.service move here?
 SYSTEMD_UNITS_EXTRA += \
                         fty-license-accepted.path \
+                        fty-proxy.path \
                         wd_keepalive@.service
 
 # These service-units are PartOf and WantedBy the "bios.target"
@@ -325,6 +326,7 @@ SYSTEMD_UNITS += $(SYSTEMD_UNITS_TARGET_BIOS) $(SYSTEMD_UNITS_LOWLEVEL)
 #SYSTEMD_UNITS_NOTPRESET_LOWLEVEL +=
 SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS += \
                         fty-envvars.service \
+                        fty-proxy.service \
                         fty-tntnet@.service \
                         bios-fake-th.service
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -230,6 +230,7 @@ ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/10-bios-gpio.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/16-machineid-dir.everytime.sh \
+	$(top_srcdir)/setup/17-proxy-file.everytime.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_builddir)/setup/20-th-names.sh \
@@ -241,6 +242,7 @@ EXTRA_DIST += \
 	$(top_srcdir)/setup/10-bios-gpio.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/16-machineid-dir.everytime.sh \
+	$(top_srcdir)/setup/17-proxy-file.everytime.sh \
 	$(top_srcdir)/setup/20-fty-compat.sh \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_srcdir)/setup/20-th-names.sh.in \

--- a/configure.ac
+++ b/configure.ac
@@ -350,6 +350,8 @@ AC_CONFIG_FILES([
         systemd/fty-db-engine.service
         systemd/fty-db-init.service
         systemd/fty-envvars.service
+        systemd/fty-proxy.path
+        systemd/fty-proxy.service
         systemd/fty-tntnet@.service
         systemd/ifplug-dhcp-autoconf.service
         systemd/ipc-meta-setup.service

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -150,16 +150,23 @@ cat > /etc/issue << EOF
 \S{NAME} \S{VERSION_ID} \n \l@\b ; Current IP(s): \4{eth0} \4{eth1} \4{eth2} \4{eth3} \4{LAN1} \4{LAN2} \4{LAN3}
 EOF
 
-# 42ity configuration file
+# 42ity default configuration files
 mkdir -p /etc/default
 # Common envvars for systemd services, primarily
 touch /etc/default/fty
 chown www-data /etc/default/fty
 chmod 644 /etc/default/fty
+# Specific envvars for systemd services and maybe shell: the HTTP(S) proxy
+# to connect to the licensing server, new image downloads, etc. from agents.
+# Note: authoritative copy and rights are managed in 17-proxy-file.everytime.sh
+touch /etc/default/fty-proxy
+chown www-data:bios-admin /etc/default/fty-proxy
+chmod 664 /etc/default/fty-proxy
 # ZConfig default settings, if populated
 touch /etc/default/fty.cfg
 chown www-data /etc/default/fty.cfg
-#42ity log configuration file 
+
+# 42ity log configuration file
 mkdir -p /etc/fty/
 touch /etc/fty/ftylog.cfg
 chmod 644 /etc/fty/ftylog.cfg

--- a/setup/17-proxy-file.everytime.sh
+++ b/setup/17-proxy-file.everytime.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2018 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    17-proxy-file.everytime.sh
+#  \brief   Make sure a properly owned file for HTTP(S) proxy setup exists
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#
+
+# Specific envvars for systemd services and maybe shell: the HTTP(S) proxy
+# to connect to the licensing server, new image downloads, etc. from agents.
+PROXY_FILE="/etc/default/fty-proxy"
+PROXY_FILE_PROFILE="/etc/profile.d/fty-proxy.sh"
+if test ! -s "$PROXY_FILE" ; then
+    touch "$PROXY_FILE"
+fi
+# Not in the "if" above so we can change it in later revisions if needed
+chown www-data:bios-admin "$PROXY_FILE"
+chmod 664 "$PROXY_FILE"
+
+if test ! -s "$PROXY_FILE_PROFILE" ; then
+    rm -f "$PROXY_FILE_PROFILE"
+    ln -fsr "$PROXY_FILE" "$PROXY_FILE_PROFILE"
+fi
+
+echo "`date -u`: Ensured usable file for HTTP(S) proxy setup:"
+ls -la "$PROXY_FILE" "$PROXY_FILE_PROFILE"

--- a/systemd/fty-proxy.path.in
+++ b/systemd/fty-proxy.path.in
@@ -1,0 +1,15 @@
+# This unit fires whenever the monitored pathname is written to, with its
+# action being to try enabling the target Unit. The latter can also start
+# by itself during subsequent boots, thanks to the file already existing.
+# The target Unit by itself also has a Condition on this file to be not empty.
+
+[Unit]
+Description=Tracker that the 42ity proxy config file was changed
+PartOf=bios.target
+
+[Path]
+PathModified=@sysconfdir@/default/fty-proxy
+#PathExists=@sysconfdir@/default/fty-proxy
+
+[Install]
+WantedBy=bios.target

--- a/systemd/fty-proxy.service.in
+++ b/systemd/fty-proxy.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Prepare common run-time environment variables for 42ity services
+Description=Track that the proxy config was changed, for dependent units to react
 After=local-fs.target
 Requires=local-fs.target
 PartOf=bios.target

--- a/systemd/fty-proxy.service.in
+++ b/systemd/fty-proxy.service.in
@@ -1,0 +1,17 @@
+[Unit]
+Description=Prepare common run-time environment variables for 42ity services
+After=local-fs.target
+Requires=local-fs.target
+PartOf=bios.target
+
+[Service]
+Type=oneshot
+# the service shall be considered active even when all its processes exited
+RemainAfterExit=yes
+Restart=no
+User=root
+Group=root
+ExecStart=/bin/ls -la @sysconfdir@/default/fty-proxy
+
+[Install]
+WantedBy=bios.target

--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -20,6 +20,7 @@ EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 # Note: for webserver the DB credentials file is optional,
 # since acceptance of license via REST API starts the database
 EnvironmentFile=-@sysconfdir@/default/bios-db-rw
+#EnvironmentFile=-@sysconfdir@/default/fty-proxy
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 PrivateTmp=true
 ExecStartPre=@datadir@/@PACKAGE@/scripts/tntnet-ExecStartPre.sh %i

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -3,7 +3,7 @@ Description = Initial IPC setup on target system
 DefaultDependencies=no
 After = local-fs.target
 Requires = local-fs.target
-Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service avahi-daemon.service
+Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service avahi-daemon.service fty-proxy.service fty-proxy.path
 #Requires = bios.target bios.service
 
 [Service]


### PR DESCRIPTION
Solution: prepare an /etc/default/fty-proxy with presumably sufficient access rights

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>