### PR TITLE
Revert "fty-proxy.service.in : cause the service to try-restart (if r…

### DIFF
--- a/systemd/fty-proxy.service.in
+++ b/systemd/fty-proxy.service.in
@@ -9,7 +9,6 @@ Type=oneshot
 User=root
 Group=root
 ExecStart=/bin/ls -la @sysconfdir@/default/fty-proxy
-ExecStartPost=/bin/dash -c "/bin/systemctl try-restart --no-block -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundBy fty-proxy.service | cut -d= -f2 | sort | uniq | tr '\n' ' ')"
 
 [Install]
 WantedBy=bios.target


### PR DESCRIPTION
…unning) its consumers upon (re-)enablement"

This breaks the EULA acceptance, because the restart command eventually
kills the start-db-services script. This revert is a minimal change to
unbreak EULA acceptance. I am aware that it breaks proxy handling in
return, but this should be properly solved by making users of the proxy
re-read the file each time time an http request is made, instead of
restarting processes.

This reverts commit e19908cc415632734518cf5bdd4a182c3af55a51.