### PR TITLE
[DO NOT MERGE] Set default infos for builtin agents

### DIFF
--- a/database/mysql/0014_user_preferences.sql
+++ b/database/mysql/0014_user_preferences.sql
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright (C) 2017-2018 Eaton
+ *
+ * This software is confidential and licensed under Eaton Proprietary License
+ * (EPL or EULA).
+ *
+ * This software is not authorized to be used, duplicated or disclosed to
+ * anyone without the prior written permission of Eaton.
+ * Limitations, restrictions and exclusions of the Eaton applicable standard
+ * terms and conditions, such as its EPL and EULA, apply.
+ *
+ */
+
+/*
+ * @file    0014_user_preferences.sql
+ * @brief   User preferences builtin data.
+ */
+
+
+/* For details on schema version support see the main initdb.sql */
+SET @bios_db_schema_version = '201806140001';
+SET @bios_db_schema_filename = '0014_user_management.sql';
+
+use box_utf8;
+
+/* This should be the first action in the SQL file */
+START TRANSACTION;
+INSERT INTO t_bios_schema_version (tag, timestamp, filename, version) VALUES('begin-import', UTC_TIMESTAMP() + 0, @bios_db_schema_filename, @bios_db_schema_version);
+/* Report the value */
+SELECT * FROM t_bios_schema_version WHERE tag = 'begin-import' order by id desc limit 1;
+COMMIT;
+
+
+INSERT IGNORE INTO t_bios_agent_info(agent_name, info) VALUES
+    ("1001", '"preferences":{"email" : " ", "telephone" : " ", "organization" : " ", "date":"DDMMYYYY", "temperature":"C", "language":"en-us", "time":"24h"}'),
+    ("1002", '"preferences":{"email" : " ", "telephone" : " ", "organization" : " ", "date":"DDMMYYYY", "temperature":"C", "language":"en-us", "time":"24h"}');
+
+
+/* This must be the last line of the SQL file */
+START TRANSACTION;
+INSERT INTO t_bios_schema_version (tag, timestamp, filename, version) VALUES('finish-import', UTC_TIMESTAMP() + 0, @bios_db_schema_filename, @bios_db_schema_version);
+/* Report the value */
+SELECT * FROM t_bios_schema_version WHERE tag = 'finish-import' order by id desc limit 1;
+COMMIT;

--- a/database/mysql/0014_user_preferences.sql
+++ b/database/mysql/0014_user_preferences.sql
@@ -31,10 +31,14 @@ INSERT INTO t_bios_schema_version (tag, timestamp, filename, version) VALUES('be
 SELECT * FROM t_bios_schema_version WHERE tag = 'begin-import' order by id desc limit 1;
 COMMIT;
 
+\! /bin/rm -f /tmp/0013_um_envvars.sql
+\! /usr/share/bios/scripts/generate_env_user4sql.sh -O /tmp/0013_um_envvars.sql
+SOURCE /tmp/0013_um_envvars.sql;
+\! /bin/rm -f /tmp/0013_um_envvars.sql
 
 INSERT IGNORE INTO t_bios_agent_info(agent_name, info) VALUES
-    ("1001", '"preferences":{"email" : " ", "telephone" : " ", "organization" : " ", "date":"DDMMYYYY", "temperature":"C", "language":"en-us", "time":"24h"}'),
-    ("1002", '"preferences":{"email" : " ", "telephone" : " ", "organization" : " ", "date":"DDMMYYYY", "temperature":"C", "language":"en-us", "time":"24h"}');
+    (CAST(@ENV_ADMIN as CHAR(50)), '"preferences":{"email" : " ", "telephone" : " ", "organization" : " ", "date":"DDMMYYYY", "temperature":"C", "language":"en-us", "time":"24h"}'),
+    (CAST(@ENV_MONITOR as CHAR(50)), '"preferences":{"email" : " ", "telephone" : " ", "organization" : " ", "date":"DDMMYYYY", "temperature":"C", "language":"en-us", "time":"24h"}');
 
 
 /* This must be the last line of the SQL file */

--- a/database/mysql/Makefile.am
+++ b/database/mysql/Makefile.am
@@ -15,7 +15,8 @@ mysql_DATA	= initdb.sql \
 			0010_super_parent_names.sql \
 			0011_default_rc.sql \
 			0012_device_type_extension.sql \
-			0013_user_management.sql
+			0013_user_management.sql \
+			0014_user_preferences.sql
 
 mysqlexdir	= $(datadir)/@PACKAGE@/examples/sql/mysql
 mysqlex_DATA	= \


### PR DESCRIPTION
Alternative (and much simpler) fix for https://github.com/42ity/fty-rest/pull/466. Give default preferences to builtin users so that the proprietary endpoint always has something to return.