### PR TITLE
Problem: factory-reset-live does not recreate ipc-meta-setup

### DIFF
--- a/tools/factory-reset-live.sh.in
+++ b/tools/factory-reset-live.sh.in
@@ -146,8 +146,12 @@ do_unstate() {
         esac
     done
 
-    logmsg_info "Recreating blank IPM service state files and directories..."
+    logmsg_info "Recreating blank IPM service state files and directories - systemd..."
     systemd-tmpfiles --create
+
+    logmsg_info "Recreating blank IPM service state files and directories - ipc-meta-setup..."
+    systemctl restart ipc-meta-setup
+
     if [ "$ENABLESVC" = yes ]; then
         logmsg_info "Starting IPM services..."
         systemctl start bios.service || die "Can not ensure IPM daemons are running"


### PR DESCRIPTION
Solution: restart that service to reapply things, hope for the best :)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>