### PR TITLE
Fix domain processing in envvars-ExecStartPre.sh.in

### DIFF
--- a/tools/envvars-ExecStartPre.sh.in
+++ b/tools/envvars-ExecStartPre.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2014-2017 Eaton
+# Copyright (C) 2014-2018 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -138,7 +138,7 @@ unset IFS_OLD
 # A comma-separated list of domain names (if any) that can be part of
 # this machine's FQDN when coupled with the hostname above. Note that
 # generally definition of "domain" is domain-dependent (pun intended).
-ENV_KNOWNDOMAINS="$(echo $ENV_DOMAINNAME $ENV_DNSDOMAINNAME $ENV_RESOLVDOMAINS | sort -n | uniq | tr '\n' ',' | sed 's/,$//')"
+ENV_KNOWNDOMAINS="$(echo $ENV_DOMAINNAME $ENV_DNSDOMAINNAME $ENV_RESOLVDOMAINS | tr ' ' '\n' | sort -n | uniq | tr '\n' ',' | sed 's/,$//')"
 
 list_hostnames_raw() {
     # Map known "this-host" IP addresses to known hostnames


### PR DESCRIPTION
Avoid duplicate space-separated domain names (from default and resolv) in `ENV_KNOWNDOMAINS` and subsequently bogus value(s) in `ENV_KNOWNFQDNS`.

WAS:
````
ENV_KNOWNDOMAINS='lab.xxx.com lab.xxx.com'
ENV_KNOWNFQDNS='jenkins2-rc3.lab.xxx.com,jenkins2-rc3.lab.xxx.com lab.xxx.com'
````

NOW:
````
ENV_KNOWNDOMAINS='lab.xxx.com'
ENV_KNOWNFQDNS='jenkins2-rc3.lab.xxx.com'
````