### PR TITLE
Add fty-auth layer to sshd PAM config (1.4)

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -402,6 +402,7 @@ fi
 # Setup 42ity security
 mkdir -p /etc/pam.d
 cp /usr/share/fty/examples/config/pam.d/* /etc/pam.d
+sed -i '/@include common-auth/i@include fty-auth' /etc/pam.d/sshd
 case "$IMGTYPE" in
     *devel*) ;;
     *) sed -i "s|\\(.*pam_cracklib.so\\).*|    password\tinclude\t\tfty-password|" /etc/pam.d/common-password ;;


### PR DESCRIPTION
This will make the SSH server sensitive to the FTY pam_tally2.so
configutation, to prevent locked out users from accessing the system
through SSH.

This will have an effect only if the account lockout is enabled (which
is not by default) and will not affect public key authentication.