### PR TITLE
Journald sync

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -245,9 +245,10 @@ ln -sr /usr/share/augeas/lenses/dist/{build,ethers,interfaces,ntp,ntpd,pam,resol
 echo '/dev/mtd3 0x00000 0x40000 0x40000' > /etc/fw_env.config
 
 # journald setup; note we keep it in RAM and want it updated ASAP
-sed -i 's|.*RuntimeMaxFileSize.*|RuntimeMaxFileSize=10M|' /etc/systemd/journald.conf
-sed -i 's|.*Storage.*|Storage=volatile|'                  /etc/systemd/journald.conf
-sed -i 's|.*SyncIntervalSec.*|SyncIntervalSec=1s|'        /etc/systemd/journald.conf
+sed -e 's|.*RuntimeMaxFileSize.*|RuntimeMaxFileSize=10M|' \
+    -e 's|.*Storage.*|Storage=volatile|' \
+    -e 's|.*SyncIntervalSec.*|SyncIntervalSec=1s|' \
+    -i /etc/systemd/journald.conf
 
 # rsyslogd setup
 mkdir -p /etc/rsyslog.d /etc/rsyslog.d-early /var/spool/rsyslog

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -245,6 +245,8 @@ ln -sr /usr/share/augeas/lenses/dist/{build,ethers,interfaces,ntp,ntpd,pam,resol
 echo '/dev/mtd3 0x00000 0x40000 0x40000' > /etc/fw_env.config
 
 # journald setup; note we keep it in RAM and want it updated ASAP
+# NOTE: This 1s+sync configuration is reasonable _ONLY_ on volatile log.
+#       Do not use it with on-disk approach.
 sed -e 's|.*RuntimeMaxFileSize.*|RuntimeMaxFileSize=10M|' \
     -e 's|.*Storage.*|Storage=volatile|' \
     -e 's|.*SyncIntervalSec.*|SyncIntervalSec=1s|' \

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -244,9 +244,10 @@ ln -sr /usr/share/augeas/lenses/dist/{build,ethers,interfaces,ntp,ntpd,pam,resol
 # Setup u-Boot
 echo '/dev/mtd3 0x00000 0x40000 0x40000' > /etc/fw_env.config
 
-# journald setup
+# journald setup; note we keep it in RAM and want it updated ASAP
 sed -i 's|.*RuntimeMaxFileSize.*|RuntimeMaxFileSize=10M|' /etc/systemd/journald.conf
 sed -i 's|.*Storage.*|Storage=volatile|'                  /etc/systemd/journald.conf
+sed -i 's|.*SyncIntervalSec.*|SyncIntervalSec=1s|'        /etc/systemd/journald.conf
 
 # rsyslogd setup
 mkdir -p /etc/rsyslog.d /etc/rsyslog.d-early /var/spool/rsyslog


### PR DESCRIPTION
Since we store the original journals in a memory filesystem, sync them to disk every second. The default of 5min delays our debug investigations and *seems* to botch some recording of timestamps.

NOTE: There is a small risk of this option increasing the load from `journald`, especially on systems with enabled debugging (and more messages to log), so CCing everybody I could find just to give a heads-up :)