### PR TITLE
Implement runas-_bios-script utility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,7 +179,8 @@ client_SCRIPTS +=	 \
 			tools/start-db-services \
 			tools/fty-route \
 			tools/enable-root-account \
-			tools/disable-root-account
+			tools/disable-root-account \
+			tools/runas-_bios-script
 
 helper_SCRIPTS +=	tools/tntnet-ExecStartPre.sh tools/envvars-ExecStartPre.sh tools/generate-release-details.sh tools/factory-reset-live.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -193,7 +193,8 @@ EXTRA_DIST +=		tools/fake-th \
 			tools/compress-logs \
 			tools/fty-route \
 			tools/enable-root-account \
-			tools/disable-root-account
+			tools/disable-root-account \
+			tools/runas-_bios-script
 
 # Recipe needed to fulfill ci-rc-bios.sh logic
 fake-th: tools/fake-th

--- a/docs/examples/sudoers.d/fty_00_base.in
+++ b/docs/examples/sudoers.d/fty_00_base.in
@@ -38,6 +38,7 @@ Cmnd_Alias BIOS_MYSQLDUMP   = /usr/bin/mysqldump
 Cmnd_Alias BIOS_DMF         = /usr/bin/bios-dmf
 Cmnd_Alias BIN_SYSTEMCTL    = /bin/systemctl
 Cmnd_Alias FTY_ROUTE    = @libexecdir@/@PACKAGE@/fty-route
+Cmnd_Alias RUNAS_BIOS_SCRIPT         = @libexecdir@/@PACKAGE@/runas-_bios-script
 
 # Overall, what is currently allowed with different privileges?
 Cmnd_Alias BIOS_PROGS	= DATE,AUGTOOL,BIOS_PASSWD,BIOS_PASSWD_FTY_REST,BIOS_SYSTEMCTL,BIOS_JOURNALCTL,BIOS_NUTCONFIG,BIOS_UPDATE_RC3,BIOS_MOUNT_USB,BIOS_UMOUNT_USB,BIOS_LOGHOST_RSYSLOG,BIOS_MYSQLDUMP,BIOS_DIAGNOSTIC,BIOS_DMF,FTY_ROUTE
@@ -48,4 +49,4 @@ User_Alias BIOS_USERS	= %bios-admin,www-data,%bios-infra
 Runas_Alias BIOS_RUNAS	= root
 
 BIOS_USERS ALL=(BIOS_RUNAS) NOPASSWD:BIOS_PROGS
-www-data   ALL=(BIOS_RUNAS) NOPASSWD:BIN_SYSTEMCTL
+www-data   ALL=(BIOS_RUNAS) NOPASSWD:BIN_SYSTEMCTL,RUNAS_BIOS_SCRIPT

--- a/tools/runas-_bios-script
+++ b/tools/runas-_bios-script
@@ -1,0 +1,29 @@
+#!/bin/bash
+_TIMEOUT=60
+
+if [[ "$EUID" -ne 0 ]]; then
+   echo "This utility must be run as root"
+   exit 1
+fi
+
+while getopts t:c:e: name
+do
+  case "$name" in
+  t)
+    _TIMEOUT="$OPTARG";;
+  e)
+    export "$OPTARG";;
+  ?)
+    usage;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+# We need to properly quote/escape the command to not mung it.
+COMMAND=
+for i; do
+  COMMAND="$COMMAND \"$(echo "$i" | sed -e 's/\\/\\\\/' -e 's/"/\\"/')\""
+done
+
+(cd /tmp && /usr/bin/timeout "$_TIMEOUT" /bin/su _bios-script -s '/bin/sh' -c "$COMMAND")

--- a/tools/runas-_bios-script
+++ b/tools/runas-_bios-script
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Eaton
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
 _TIMEOUT=60
 
 if [[ "$EUID" -ne 0 ]]; then
@@ -6,7 +24,18 @@ if [[ "$EUID" -ne 0 ]]; then
    exit 1
 fi
 
-while getopts t:c:e: name
+function usage {
+  (2>&1 cat <<EOF
+Usage: runas-_bios-script [-e V=v ...] [-t timeout] program [arguments ...]
+  -e V=v     : set environment variable V to value v
+  -t timeout : terminate program after _timeout_ seconds
+
+EOF
+  )
+  exit 1
+}
+
+while getopts t:e:? name
 do
   case "$name" in
   t)
@@ -19,6 +48,11 @@ do
 done
 
 shift $(($OPTIND - 1))
+
+if [ -z "$1" ]
+then
+  usage
+fi
 
 # We need to properly quote/escape the command to not mung it.
 COMMAND=


### PR DESCRIPTION
This utility allows tntnet to spawn commands as `_bios-script`. This is intended for running user scripts provided by fty-scripts-rest and maybe other components in the future.

Precautions were taken to prevent string injection attacks, but this is a safe design only as far as user priviledges go. A more thorough sandboxing scheme would require the usage of Linux namespaces/cgroups/ulimits, but this should be good enough as a first approximation to be eventually refined later.