### PR TITLE
Create NUT internal users on nut-server start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ docs/doxygen/*.tmp
 
 docs/examples/sudoers.d/fty_00_base
 !docs/examples/sudoers.d/fty_00_base.in
+docs/examples/nut-server.service.d/configure-nut-users.conf
+!docs/examples/nut-server.service.d/configure-nut-users.conf.in
 
 .test.log
 .test.trs

--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,8 @@ tools/tntnet-ExecStartPre.sh
 tools/envvars-ExecStartPre.sh
 !tools/start-db-services.in
 tools/start-db-services
+!tools/setup-nut-users-ExecStartPre.sh.in
+tools/setup-nut-users-ExecStartPre.sh
 
 src/web/src/auth-verify.cpp
 src/web/src/auth-require.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -183,7 +183,7 @@ client_SCRIPTS +=	 \
 			tools/runas-_bios-script \
 			tools/run-user-script
 
-helper_SCRIPTS +=	tools/tntnet-ExecStartPre.sh tools/envvars-ExecStartPre.sh tools/generate-release-details.sh tools/factory-reset-live.sh
+helper_SCRIPTS +=	tools/tntnet-ExecStartPre.sh tools/envvars-ExecStartPre.sh tools/generate-release-details.sh tools/factory-reset-live.sh tools/setup-nut-users-ExecStartPre.sh
 
 EXTRA_DIST +=		tools/fake-th \
 			tools/bios-networking \

--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,7 @@ AC_CONFIG_FILES([
         docs/examples/rsyslog.d/05-bash.conf
         docs/examples/rsyslog.d/10-ipc.conf
         docs/examples/sudoers.d/fty_00_base
+        docs/examples/nut-server.service.d/configure-nut-users.conf
         docs/examples/update-rc3.d/90-local-paths.rc3.conf
         systemd/bios-agent-inventory.service
         systemd/bios-fake-th.service

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,7 @@ AC_CONFIG_FILES([
         setup/20-th-names.sh
         tools/db-init
         tools/envvars-ExecStartPre.sh
+        tools/setup-nut-users-ExecStartPre.sh
         tools/factory-reset-live.sh
         tools/run-test-doc.sh
         tools/start-db-services

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -45,7 +45,7 @@ examplelog_DATA = \
                    ftylog.d/10-ftylog.cfg \
                    ftylog.d/20-wwwlog.cfg
 
-examplenutserverdir	= /lib/systemd/system/nut-server.service.d
+examplenutserverdir	= $(systemdsystemunitdir)/nut-server.service.d
 examplenutserver_DATA = \
 			nut-server.service.d/configure-nut-users.conf
 

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -45,4 +45,8 @@ examplelog_DATA = \
                    ftylog.d/10-ftylog.cfg \
                    ftylog.d/20-wwwlog.cfg
 
-EXTRA_DIST += $(examplecfgsudo_DATA) $(examplecfgpam_DATA) $(examplecfgsec_DATA) $(examplecfgupdate_DATA) $(examplecfgrsyslogd_DATA) $(exampleprofile_DATA) $(exampleudevrules_DATA) $(examplelog_DATA)
+examplenutserverdir	= /lib/systemd/system/nut-server.service.d
+examplenutserver_DATA = \
+			nut-server.service.d/configure-nut-users.conf
+
+EXTRA_DIST += $(examplecfgsudo_DATA) $(examplecfgpam_DATA) $(examplecfgsec_DATA) $(examplecfgupdate_DATA) $(examplecfgrsyslogd_DATA) $(exampleprofile_DATA) $(exampleudevrules_DATA) $(examplelog_DATA) $(examplenutserver_DATA)

--- a/docs/examples/nut-server.service.d/configure-nut-users.conf.in
+++ b/docs/examples/nut-server.service.d/configure-nut-users.conf.in
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=@libexecdir@/@PACKAGE@/setup-nut-users-ExecStartPre.sh

--- a/tools/setup-nut-users-ExecStartPre.sh
+++ b/tools/setup-nut-users-ExecStartPre.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+#   Copyright (c) 2014-2018 Eaton
+#
+#   This file is part of the Eaton $BIOS project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    setup-nut-users-ExecStartPre.sh
+#  \brief   Script to create NUT users before starting NUT
+#  \author  Jean-Baptiste Boric <JeanBaptisteBoric@Eaton.com>
+#
+
+# Set up a NUT administrator
+if [ ! -f /etc/default/bios-nut-admin ]
+then
+    nut_bios_user=bios-administrator
+    nut_bios_password=$(dd if=/dev/urandom count=1 bs=16 2>/dev/null | md5sum | cut -f1 -d' ')
+    echo "Creating NUT internal user $nut_bios_user..."
+
+    # Add user to NUT configuration
+    cat <<EOF >>/etc/nut/upsd.users
+
+[$nut_bios_user]
+    password = $nut_bios_password
+    actions = SET
+    instcmds = ALL
+
+EOF
+
+    # Store credentials in a environment variable file
+    touch /etc/default/bios-nut-admin
+    chmod 660 /etc/default/bios-nut-admin
+    chown bios /etc/default/bios-nut-admin
+    cat <<EOF >/etc/default/bios-nut-admin
+NUT_USER="$nut_bios_user"
+NUT_PASSWD="$nut_bios_password"
+EOF
+fi

--- a/tools/setup-nut-users-ExecStartPre.sh.in
+++ b/tools/setup-nut-users-ExecStartPre.sh.in
@@ -24,14 +24,14 @@
 #
 
 # Set up a NUT administrator
-if [ ! -f /etc/default/bios-nut-admin ]
+if [ ! -f @sysconfdir@/default/bios-nut-admin ]
 then
     nut_bios_user=bios-administrator
     nut_bios_password=$(dd if=/dev/urandom count=1 bs=16 2>/dev/null | md5sum | cut -f1 -d' ')
     echo "Creating NUT internal user $nut_bios_user..."
 
     # Add user to NUT configuration
-    cat <<EOF >>/etc/nut/upsd.users
+    cat <<EOF >> @sysconfdir@/nut/upsd.users
 
 [$nut_bios_user]
     password = $nut_bios_password
@@ -41,10 +41,10 @@ then
 EOF
 
     # Store credentials in a environment variable file
-    touch /etc/default/bios-nut-admin
-    chmod 660 /etc/default/bios-nut-admin
-    chown bios /etc/default/bios-nut-admin
-    cat <<EOF >/etc/default/bios-nut-admin
+    touch @sysconfdir@/default/bios-nut-admin
+    chmod 660 @sysconfdir@/default/bios-nut-admin
+    chown bios @sysconfdir@/default/bios-nut-admin
+    cat <<EOF > @sysconfdir@/default/bios-nut-admin
 NUT_USER="$nut_bios_user"
 NUT_PASSWD="$nut_bios_password"
 EOF

--- a/tools/setup-nut-users-ExecStartPre.sh.in
+++ b/tools/setup-nut-users-ExecStartPre.sh.in
@@ -1,26 +1,21 @@
 #!/bin/bash
+
 #
-#   Copyright (c) 2014-2018 Eaton
+# Copyright (C) 2014-2018 Eaton
 #
-#   This file is part of the Eaton $BIOS project.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#   This program is free software; you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 2 of the License, or
-#   (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program; if not, write to the Free Software Foundation, Inc.,
-#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
-#! \file    setup-nut-users-ExecStartPre.sh
-#  \brief   Script to create NUT users before starting NUT
-#  \author  Jean-Baptiste Boric <JeanBaptisteBoric@Eaton.com>
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
 # Set up a NUT administrator


### PR DESCRIPTION
Also create an environment file for all clients to get credentials (currently `fty-nut-command`).