### PR TITLE
Fixup configure-nut-users.conf ExecStartPre path

### DIFF
--- a/docs/examples/nut-server.service.d/configure-nut-users.conf.in
+++ b/docs/examples/nut-server.service.d/configure-nut-users.conf.in
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=@libexecdir@/@PACKAGE@/setup-nut-users-ExecStartPre.sh
+ExecStartPre=@datadir@/@PACKAGE@/scripts/setup-nut-users-ExecStartPre.sh


### PR DESCRIPTION
Helper script got installed at a location I did not expect. Adjust path.