### PR TITLE
Problem : default HWM value may block fty-agents under stress load

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -639,7 +639,7 @@ esac
 
 # according to https://github.com/42ity/malamute/blob/1.0-FTY-master/src/mlm_perftest.c#L22
 # "If we allow limits, then the engines will block under stress."
-# to avoid any block under stress, set unlimited High Water Mark on malamute client likes the broker itself
+# to avoid any block under stress, set unlimited High Water Mark on malamute clients side likes we have on the broker itself
 echo "ZSYS_SNDHWM=0" >> /usr/share/fty/etc/default/fty
 echo "ZSYS_RCVHWM=0" >> /usr/share/fty/etc/default/fty
 echo "ZSYS_PIPEHWM=0" >> /usr/share/fty/etc/default/fty

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -637,6 +637,13 @@ case "$IMGTYPE" in
         ;;
 esac
 
+# according to https://github.com/42ity/malamute/blob/1.0-FTY-master/src/mlm_perftest.c#L22
+# "If we allow limits, then the engines will block under stress."
+# to avoid any block under stress, set unlimited High Water Mark on malamute client likes the broker itself
+echo "ZSYS_SNDHWM=0" >> /usr/share/fty/etc/default/fty
+echo "ZSYS_RCVHWM=0" >> /usr/share/fty/etc/default/fty
+echo "ZSYS_PIPEHWM=0" >> /usr/share/fty/etc/default/fty
+
 # set path to our libexec directory
 echo "PATH=/usr/libexec/fty:/bin:/usr/bin:/sbin:/usr/sbin" >>/usr/share/fty/etc/default/fty
 

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -3,7 +3,7 @@ Description = Initial IPC setup on target system
 DefaultDependencies=no
 After = local-fs.target
 Requires = local-fs.target
-Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service
+Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service avahi-daemon.service
 #Requires = bios.target bios.service
 
 [Service]

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -3,7 +3,7 @@ Description = Initial IPC setup on target system
 DefaultDependencies=no
 After = local-fs.target
 Requires = local-fs.target
-Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service avahi-daemon.service
+Before = bios.target fty-envvars.service fty-license-accepted.service bios.service malamute.service sshd.service ssh.service ssh.socket systemd-logind.service network.target systemd-tmpfiles-setup.service systemd-tmpfiles-clean.service tntnet@bios.service fty-tntnet@bios.service fty-db-engine.service mysql.service mysqld.service mariadb.service saslauthd.service
 #Requires = bios.target bios.service
 
 [Service]


### PR DESCRIPTION
Problem : on heavy load activity, fty-nut stopping working after a while.
Solution : set unlimited High Water Mark on malamute clients side likes we have on the broker itself

In the detail.
on heavy load stress two Threads (3 & 4) are stucked. They are waiting forever on zmq::mailbox_t::recv.

fty-nut creates one mlm client which both subscribe and consume on different STREAM. One Thread (3) is trying to inform the application that some ASSET has been published in STREAM ASSET, and the other Thread (4) is trying to publish metrics in loop.
~~~~
                "STREAM SEND"+----------+ "STREAM DELIVER"    
mlm_client_send()----------->| msgpipe  |<-------------pass_stream_message_to_app()
Thread4:producer             +----------+              Thread 3:consumer
~~~~

For more detail information, look at https://github.com/geraldguillaume/issue-rcv which aims to reproduce the issue with a detailed analysis.
