### PR TITLE
Problem: OS image generation sometimes fails due to find /proc/...

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -594,7 +594,9 @@ rm -f /tmp/bios.xml
 
 # Disable logind
 /bin/systemctl disable systemd-logind
-find / -name systemd-logind.service -delete
+# Avoid errors looking into /run /proc and such; assume that during OS image
+# generation all the stable-FS buildroot is under same filesystem on host.
+find /etc /usr /lib -mount -name systemd-logind.service -delete
 
 # Our watchdogs - disable system ones, enable our custom service
 # Note that actual service instances work or not based on presence of the


### PR DESCRIPTION
Solution: avoid looking into it, in fact just list the needed
directory trees' contents. Avoids this very rare error message:

    [  324s] + /bin/systemctl disable systemd-logind
    [  324s] + find / -name systemd-logind.service -delete
    [  325s] find: `/proc/18251/task/18267/fd': No such file or directory
    [  325s] + exit 1

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>