### PR TITLE
Problem: New images should be listed in SW manifest

### DIFF
--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -396,6 +396,9 @@ remove_image() {
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"'\.[^\:]*'
     rm -f "$1"{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512}{,-padded}{,.tmp} ${2:+"$2"}
+    # and update the SW package manifest
+    # WARNING: this MUST be done before package manifest deletion!
+    etn-sw-update --delete-image "$1"
     # Also remove the image file manifest, if present
     MANIFEST_FILE="`echo "$1" | sed 's/.squashfs/-manifest.json/'`"
     rm -f "$MANIFEST_FILE"
@@ -951,16 +954,12 @@ download_osimage() (
     rm -f "${IMAGE_MANIFEST_URL}"
     wget -q -O - "${IMAGE_MANIFEST_URL}" > "${aIMAGE_MANIFEST_NEW}" || \
         { logmsg_error "Could not save '${IMAGE_MANIFEST_URL}' into '${aIMAGE_MANIFEST_NEW}'"
-          #rm -f "${aIMAGE_MANIFEST_NEW}" # see FIXME below
-          echo "dummy" >> "${aIMAGE_MANIFEST_NEW}" # see FIXME below
+          rm -f "${aIMAGE_MANIFEST_NEW}"
           if [ x"${CHECK_ONLY-}" = xyes ]; then
             die "Got an error while checking if there is something new to download, so no reason to proceed"
           fi
         }
 
-    # FIXME: missing manifest should be treated as an error!
-    # However, for now, since CI does not yet generate it, consider just as a warning!
-    # Just ship an empty file in the meantime, to have the whole algorithm working as expected
     if [ ! -s "${aTGT_FILE_MANIFEST}" ]; then
         [ -s "${aIMAGE_MANIFEST_NEW}" ] && cp -f "${aIMAGE_MANIFEST_NEW}" "${aTGT_FILE_MANIFEST}"
         [ -s "${aTGT_FILE_MANIFEST_NEW}" ] && cp -f "${aTGT_FILE_MANIFEST_NEW}" "${aTGT_FILE_MANIFEST}"
@@ -982,6 +981,7 @@ download_osimage() (
 
     [ -s "${aTGT_FILE}" ] && [ -s "${aTGT_FILE_CSOLD}" ] && [ -s "${aTGT_FILE_MANIFEST}" ] && \
     touch -r "${aTGT_FILE}" "${aTGT_FILE_CSOLD}" "${aTGT_FILE_MANIFEST}" && \
+    ( etn-sw-update --add-image "${aTGT_FILE}" || echo "$?" > "/var/lib/fty/sw-update/activation_requested" ) && \
     logmsg_info "Got OS image OK:" && \
     ls -ld "${aTGT_FILE}" "${aTGT_FILE_CSOLD}" "${aTGT_FILE_MANIFEST}" && \
     cat "${aTGT_FILE_CSOLD}" && \


### PR DESCRIPTION
Solution: Do it, along with updating upon image deletion
Also error out on missing package manifest, now that these are produced by CI
Note that upon successfull image download, activation request is also set to
the new image (using its index), for completion of the SW upgrade

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>