### PR TITLE
Problem: bios.xml sanity check is lax enough to fail

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#   Copyright (c) 2014-2018 Eaton
+#   Copyright (c) 2014-2019 Eaton
 #
 #   This file is part of the Eaton 42ity project.
 #
@@ -602,8 +602,14 @@ sed '/<!-- Here starts the real API -->/,$!d' \
 rm -f /etc/tntnet/bios.d/20_core.xml.tmp
 
 # Sanity check, excluding files that could be delivered by other packages
-cat /etc/tntnet/bios.d/{00_*,10_*,20_*,50_*,99_*}.xml > /tmp/bios.xml && \
-diff -bu /etc/tntnet/bios.xml /tmp/bios.xml || { echo "ERROR: bios.xml was sliced incorrectly" >&2; exit 1; }
+cat /etc/tntnet/bios.d/00_start.xml \
+    /etc/tntnet/bios.d/10_common_statics.xml \
+    /etc/tntnet/bios.d/20_common_basics.xml \
+    /etc/tntnet/bios.d/50_main_api.xml \
+    /etc/tntnet/bios.d/99_end.xml \
+> /tmp/bios.xml \
+&& diff -bu /etc/tntnet/bios.xml /tmp/bios.xml \
+|| { echo "ERROR: bios.xml was sliced incorrectly" >&2; exit 1; }
 rm -f /tmp/bios.xml
 
 /bin/systemctl enable tntnet@bios

--- a/tools/tntnet-ExecStartPre.sh.in
+++ b/tools/tntnet-ExecStartPre.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2014-2018 Eaton
+# Copyright (C) 2014-2019 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,6 +27,12 @@
 INST="`basename "$1" .service`"
 
 echo "Check requirements of tntnet@$INST instance for 42ity"
+
+# Make sure the sorting order (cat *.xml) is deterministic
+LANG=C
+LC_ALL=C
+TZ=UTC
+export LANG LC_ALL TZ
 
 set -e
 


### PR DESCRIPTION
Solution: list the filenames (and order) we expect in the sanity checker.
Avoid conflicts with components that could deliver filenames under numbered
patterns we already use.

Also ensure tntnet-ExecStartPre.sh uses the same order of filename listing.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>
Thanks: Gerald Guillaume <GeraldGuillaume@eaton.com> for finding the bug cause