### PR TITLE
Problem : OVA image sometime register its hostname to default localhost to the DHCP srv

### DIFF
--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -55,12 +55,6 @@ can_manipulate_ntpd() {
 }
 
 hostname_setup() {
-	case "$reason" in
-	bound|renew|BOUND|RENEW|REBIND|REBOOT)
-		;;
-	*)
-		return
-	esac
 	if test -s /etc/hostname; then
 		return
 	fi

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -55,6 +55,12 @@ can_manipulate_ntpd() {
 }
 
 hostname_setup() {
+    case "$reason" in
+	bound|renew|BOUND|RENEW|REBIND|REBOOT)
+		;;
+	*)
+		echo "$0: WARN: hostname_setup got an unexpected reason '$reason'"
+	esac
 	if test -s /etc/hostname; then
 		return
 	fi

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -56,10 +56,11 @@ can_manipulate_ntpd() {
 
 hostname_setup() {
     case "$reason" in
-	bound|renew|BOUND|RENEW|REBIND|REBOOT)
-		;;
-	*)
-		echo "$0: WARN: hostname_setup got an unexpected reason '$reason'"
+        bound|renew|BOUND|RENEW|REBIND|REBOOT)
+            ;;
+        *)
+            echo "$0: WARN: hostname_setup got an unexpected reason '$reason'"
+            ;;
 	esac
 	if test -s /etc/hostname; then
 		return


### PR DESCRIPTION
My hypothesis is that sometime the "$reason" does not belong to the list bound|renew|BOUND|RENEW|REBIND|REBOOT, so we failed in the default case which return, so we lost the chance to initialize properly the hostname.
Solution, do not take in account the "$raeson" to force the hostname initialization happening in every cases.

Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>