### PR TITLE
Run disable-root-account in another cgroup (1.5.0)

### DIFF
--- a/tools/enable-root-account
+++ b/tools/enable-root-account
@@ -100,4 +100,4 @@ usermod -s /bin/bash root
 ### Uncomment this line to ease debugging in shell
 #echo "root:$ROOT_PASSWORD"
 
-disable-root-account -t "$SLEEP_MINUTES" &
+systemd-run /usr/libexec/fty/disable-root-account -t "$SLEEP_MINUTES"


### PR DESCRIPTION
Prevents issue when `enable-root-account` unintentionally spawns long-running processes, interfering with SystemD unit shutdown detection when running it inside a service.

Backport of #324 for 1.5.0.