### PR TITLE
preinstallimage-bios.sh.in : remove apt (and possibly other perl…

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -384,7 +384,7 @@ EOF
 
 # Uninstall various packages that are not needed
 # Note: We restore "/bin/diff" and "/bin/*grep" via busybox, below
-for i in $(dpkg -l | awk '/perl/{ print $2; }') apt fakeroot ncurses-bin diffutils grep sysvinit ncurses-common lsb-release; do
+for i in apt fakeroot ncurses-bin diffutils grep sysvinit ncurses-common lsb-release $(dpkg -l | awk '/perl/{ print $2; }'); do
     case "$IMGTYPE" in
         *devel*)
             echo dpkg -P --force-all $i


### PR DESCRIPTION
…consumers) before perl bits themselves

In case of `apt`, apparently its preremove/postremove handling scripts need Perl in the Debian9 version of the package. So having no perl was a problem for removing the package.