### PR TITLE
enable-root-account improvements for CI automation

### DIFF
--- a/tools/disable-root-account
+++ b/tools/disable-root-account
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2018 Eaton
+# Copyright (C) 2018-2019 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,7 +38,7 @@ get_a_string_arg() { "$JSONSH" -x "$1" | (IFS="`printf '\t'`" read K V; echo "$V
 J="/etc/release-details.json"
 img_type="$(get_a_string_arg osimage-img-type < $J)"
 
-ROOT_PASSWORD_LOCATION=/tmp/.rootpwd
+ROOT_PASSWORD_LOCATION="/tmp/.rootpwd"
 
 die() {
     echo "FATAL: $*" >&2

--- a/tools/enable-root-account
+++ b/tools/enable-root-account
@@ -59,6 +59,9 @@ case "$img_type" in
 esac
 
 if [[ -s "$ROOT_PASSWORD_LOCATION" ]] ; then
+    ### Uncomment this line to ease debugging in shell or CI
+    #ROOT_PASSWORD="`cat "$ROOT_PASSWORD_LOCATION"`"
+    #echo "root:$ROOT_PASSWORD"
     die "Previous password still valid"
 fi
 

--- a/tools/enable-root-account
+++ b/tools/enable-root-account
@@ -60,8 +60,8 @@ esac
 
 if [[ -s "$ROOT_PASSWORD_LOCATION" ]] ; then
     ### Uncomment this line to ease debugging in shell or CI
-    #ROOT_PASSWORD="`cat "$ROOT_PASSWORD_LOCATION"`"
-    #echo "root:$ROOT_PASSWORD"
+    #@CI_UNCOMMENT@#ROOT_PASSWORD="`cat "$ROOT_PASSWORD_LOCATION"`"
+    #@CI_UNCOMMENT@#echo "root:$ROOT_PASSWORD"
     die "Previous password still valid"
 fi
 
@@ -101,6 +101,6 @@ echo "root:$ROOT_PASSWORD" | chpasswd
 usermod -s /bin/bash root
 
 ### Uncomment this line to ease debugging in shell or CI
-#echo "root:$ROOT_PASSWORD"
+#@CI_UNCOMMENT@#echo "root:$ROOT_PASSWORD"
 
 systemd-run /usr/libexec/fty/disable-root-account -t "$SLEEP_MINUTES"

--- a/tools/enable-root-account
+++ b/tools/enable-root-account
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2018 Eaton
+# Copyright (C) 2018-2019 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@ img_type="$(get_a_string_arg osimage-img-type < $J)"
 
 umask 077
 
-ROOT_PASSWORD_LOCATION=/tmp/.rootpwd
+ROOT_PASSWORD_LOCATION="/tmp/.rootpwd"
 
 die() {
     echo "FATAL: $*" >&2
@@ -58,7 +58,7 @@ case "$img_type" in
         ;;
 esac
 
-if [[ -s $ROOT_PASSWORD_LOCATION ]] ; then
+if [[ -s "$ROOT_PASSWORD_LOCATION" ]] ; then
     die "Previous password still valid"
 fi
 
@@ -97,7 +97,7 @@ echo "Root shell enabled and password changed"
 echo "root:$ROOT_PASSWORD" | chpasswd
 usermod -s /bin/bash root
 
-### Uncomment this line to ease debugging in shell
+### Uncomment this line to ease debugging in shell or CI
 #echo "root:$ROOT_PASSWORD"
 
 systemd-run /usr/libexec/fty/disable-root-account -t "$SLEEP_MINUTES"


### PR DESCRIPTION
These changes should ease application and use of "CI Hacks" that simplify test deployments a lot, while not impacting the end-user systems "as is".