### PR TITLE
FTY hostname setup and other DHCP client fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -177,6 +177,7 @@ client_SCRIPTS +=	 \
 			tools/verify-fs \
 			tools/diagnostic-information \
 			tools/start-db-services \
+			tools/fty-hostname-setup \
 			tools/fty-route \
 			tools/enable-root-account \
 			tools/disable-root-account \
@@ -192,6 +193,7 @@ EXTRA_DIST +=		tools/fake-th \
 			tools/generate-release-details.sh \
 			tools/loghost-rsyslog \
 			tools/compress-logs \
+			tools/fty-hostname-setup \
 			tools/fty-route \
 			tools/enable-root-account \
 			tools/disable-root-account \
@@ -330,7 +332,9 @@ SYSTEMD_UNITS += $(SYSTEMD_UNITS_TARGET_BIOS) $(SYSTEMD_UNITS_LOWLEVEL)
 # script or during deployment's lifetime).
 # Note: Due to conflict with "tntnet@.service" file from tntnet package,
 # we name ours differently here (and override during OS image generation).
-#SYSTEMD_UNITS_NOTPRESET_LOWLEVEL +=
+SYSTEMD_UNITS_NOTPRESET_LOWLEVEL += \
+                        fty-hostname-setup.service
+
 SYSTEMD_UNITS_NOTPRESET_TARGET_BIOS += \
                         fty-envvars.service \
                         fty-tntnet@.service \

--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,7 @@ AC_CONFIG_FILES([
         systemd/fty-db-engine.service
         systemd/fty-db-init.service
         systemd/fty-envvars.service
+        systemd/fty-hostname-setup.service
         systemd/fty-tntnet@.service
         systemd/ifplug-dhcp-autoconf.service
         systemd/ipc-meta-setup.service

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -822,6 +822,8 @@ install -m 0755 /usr/share/fty/scripts/ethtool-static-nolink /etc/network/if-pre
 install -m 0755 /usr/share/fty/scripts/ifupdown-force /etc/ifplugd/action.d/ifupdown-force
 install -m 0755 /usr/share/fty/scripts/udhcpc-override.sh /usr/local/sbin/udhcpc
 echo '[ -s /usr/share/fty/scripts/udhcpc-hook.sh ] && . /usr/share/fty/scripts/udhcpc-hook.sh' >> /etc/udhcpc/default.script
+# Get it into our default PATH:
+ln -fsr /usr/libexec/fty/fty-hostname-setup /usr/local/sbin/fty-hostname-setup
 
 # Newer /sbin/{ifup,ifdown,ifquery} no longer call tools by just the short
 # program name, but do it using the full path e.g. /sbin/ip or /sbin/udhcpc

--- a/systemd/fty-hostname-setup.service.in
+++ b/systemd/fty-hostname-setup.service.in
@@ -1,0 +1,18 @@
+[Unit]
+Description=Prepare standard hostname for a 42ity deployment, if none is set statically
+After=local-fs.target
+Requires=local-fs.target
+Before=network-online.target
+
+[Service]
+Type=oneshot
+# the service shall be considered active even when all its processes exited
+RemainAfterExit=yes
+Restart=no
+User=root
+Group=root
+# Generate a name unless one is set, do not save to /etc/hostname yet (so DHCP may override)
+ExecStart=@libexecdir@/@PACKAGE@/fty-hostname-setup "-" false
+
+[Install]
+WantedBy=network-online.target

--- a/tools/fty-hostname-setup
+++ b/tools/fty-hostname-setup
@@ -76,6 +76,10 @@ hostname_setup() {
 			;;
 	esac
 
+	# Apply hostnamectl first, as it tends to lower-case the MAC chars
+	# Strictly speaking, modern DNS rules do not require that (though
+	# names are case-insensitive for comparisons)
+	( which hostnamectl 2>/dev/null ) && hostnamectl set-hostname "$hostname" || true
 	if [ x"$hostname" != xeaton-rc3 ] && [ "$filesave" != false ] ; then
 		echo "$hostname" >/etc/hostname
 		hostname -F /etc/hostname
@@ -83,7 +87,6 @@ hostname_setup() {
 		# Just apply the name "live" and allow this routine to re-run later
 		hostname "$hostname"
 	fi
-	( which hostnamectl 2>/dev/null ) && hostnamectl set-hostname "$hostname" || true
 
 	# Apparently, the first token for a locally available IP address is
 	# treated as the `hostname --fqdn` if no other ideas are available.

--- a/tools/fty-hostname-setup
+++ b/tools/fty-hostname-setup
@@ -30,6 +30,7 @@
 hostname_setup() {
 	local hostname="$1"
 	local filesave="$2"
+	# Caller (DHCP hook) can also export a $interface value
 
 	# By default, write the newly generated unique name (if any)
 	# to /etc/hostname. Makes sense to avoid this e.g. in early
@@ -69,8 +70,8 @@ hostname_setup() {
 	[ "$filesave" = extra-force ] || \
 	case x"$hostname" in
 		x|xeaton-rc3|xlocalhost*) # failed defaultness-check
-			echo "$0: WARN: Current (or DHCP-suggested) hostname is '$hostname', generating a default MAC-based one instead" >&2
-			hostname_addon="$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")" \
+			echo "$0: WARN: Current (or DHCP-suggested) hostname is '$hostname', generating a default MAC-based one instead (using interface='$interface')" >&2
+			hostname_addon="$(ip link show ${interface:+dev "$interface"} | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | head -1 | tr "abcdef" "ABCDEF")" \
 			&& [ -n "${hostname_addon}" ] && hostname="eaton-rc-${hostname_addon}" && echo "$0: INFO: Generated '$hostname' instead" >&2 \
 			|| { hostname="eaton-rc3" ; echo "$0: WARN: FAILED to generate a hostname based on a MAC address, fell back to '$hostname'" >&2 ; }
 			;;

--- a/tools/fty-hostname-setup
+++ b/tools/fty-hostname-setup
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Copyright (c) 2015-2019 Eaton
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    fty-hostname-setup
+#  \brief   Hostname setup for a freshly deployed rack controller
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#  \details Keep the statically defined name from /etc/hostname if
+#           available, otherwise generate one if a dummy default is
+#           passed, and save/apply it. Called from DHCP hooks and
+#           early in system boot-up.
+
+# TODO: Port from loader the logic to query DHCP server for a host name
+# if already known, for each interface found, before generating some.
+
+hostname_setup() {
+	local hostname="$1"
+	local filesave="$2"
+
+	# By default, write the newly generated unique name (if any)
+	# to /etc/hostname. Makes sense to avoid this e.g. in early
+	# stages of first boot when we might later get (and save)
+	# the name from DHCP server, pre-provisioned by a sysadmin
+	# (or stashed from earlier lifetime before factory reset).
+	# Note that we would still set /etc/hosts with this name.
+	case "$filesave" in
+		true|false|force|extra-force) ;;
+		-f) filesave=force ;; # Do it despite presence of /etc/hostname
+		-ff|-F) filesave=extra-force ;; # ...and skip defaultness check
+		*) filesave=true ;;
+	esac
+
+	if [ "$hostname" = "-" ]; then
+		# Apply existing name, if present and sane, and tweak /etc/hosts below
+		[ -s /etc/hostname ] \
+			&& hostname="`cat /etc/hostname | sed -e 's,^[ \t]*,,' -e 's,[ \t]*$,,`" \
+			|| hostname="`hostname`" \
+			|| hostname="`cat /proc/sys/kernel/hostname`"
+	else
+		if [ -s /etc/hostname ] && [ "$filesave" != force ]  && [ "$filesave" != extra-force ]; then
+			# Assume the name was already set up to whatever user
+			# wanted, before. It should then be changed locally too,
+			# including any /etc/hosts changes, if desired.
+			hostname_sys="`hostname`" && [ -n "$hostname_sys" ] \
+				|| hostname_sys="`cat /proc/sys/kernel/hostname`"
+			hostname_etc="`cat /etc/hostname | sed -e 's,^[ \t]*,,' -e 's,[ \t]*$,,`"
+			if [ "$hostname" != "$hostname_etc" ] || [ "$hostname" != "$hostname_sys" ]; then
+				echo "$0: WARN: Passed hostname candidate is '$hostname', while kernel says '$hostname_sys' and /etc/hostname says '$hostname_etc': leaving them untouched!" >&2
+			fi
+			return
+		fi
+	fi
+
+	# If someone really forces something... let them
+	[ "$filesave" = extra-force ] || \
+	case x"$hostname" in
+		x|xeaton-rc3|xlocalhost*) # failed defaultness-check
+			echo "$0: WARN: Current (or DHCP-suggested) hostname is '$hostname', generating a default MAC-based one instead" >&2
+			hostname_addon="$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")" \
+			&& [ -n "${hostname_addon}" ] && hostname="eaton-rc-${hostname_addon}" && echo "$0: INFO: Generated '$hostname' instead" >&2 \
+			|| { hostname="eaton-rc3" ; echo "$0: WARN: FAILED to generate a hostname based on a MAC address, fell back to '$hostname'" >&2 ; }
+			;;
+	esac
+
+	if [ x"$hostname" != xeaton-rc3 ] && [ "$filesave" != false ] ; then
+		echo "$hostname" >/etc/hostname
+		hostname -F /etc/hostname
+	else
+		# Just apply the name "live" and allow this routine to re-run later
+		hostname "$hostname"
+	fi
+	( which hostnamectl 2>/dev/null ) && hostnamectl set-hostname "$hostname" || true
+
+	# Apparently, the first token for a locally available IP address is
+	# treated as the `hostname --fqdn` if no other ideas are available.
+	if [ -s /etc/hosts ]; then
+		grep -wi "$hostname" etc/hosts >/dev/null 2>&1 || \
+			sed -e 's,^[ \t]*\(127[^ \t]*[ \t]\)\(.*[ \t]*localhost[ \t]*\),\1'"$hostname"'\t\2\t,' -i /etc/hosts
+	else
+		echo "127.0.0.1 $hostname   localhost" > /etc/hosts
+	fi
+}
+
+#exec >> /dev/console 2>&1
+#set >&2
+#set -x
+
+case "$1" in
+	help|-help|--help)
+		echo "Usage: $0 [candidate_hostname] [save_flag]"
+		echo "Note that normally the candidate_hostname would not be applied if already"
+		echo "/etc/hostname has something, and it is subject to a defaultness check:"
+		echo "if candidate_hostname is empty (or localhost or eaton-rc3) then generate"
+		echo "a MAC-based name. If candidate_hostname is '-' try to apply /etc/hostname"
+		echo "or the current kernel hostname, subject to defaultness check".
+		echo "If save_flag is 'false' then the name is not saved to /etc/hostname, or"
+		echo "if save_flag is 'force' or 'force-extra' (bypass defaultness check) then"
+		echo "the name is applied and saved even if the file existed before."
+		exit 1
+		;;
+esac
+
+hostname_setup "$@"

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -69,12 +69,13 @@ hostname_setup() {
             ;;
 	esac
 	if test -s /etc/hostname; then
-		# Assume the name was already set up to whatever user wanted
+		# Assume the name was already set up to whatever user wanted before
 		return
 	fi
 	case x"$hostname" in
 		x|xeaton-rc3|xlocalhost*)
-			hostname=eaton-rc-$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")
+			echo "$0: WARN: Current (or DHCP-suggested) hostname is '$hostname', generating a default MAC-based one instead" >&2
+			hostname="eaton-rc-$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")"
 			;;
 	esac
 
@@ -206,4 +207,3 @@ fi
 hostname_setup
 
 ntp_servers_setup
-

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -82,8 +82,12 @@ hostname_setup() {
 			;;
 	esac
 
-	echo "$hostname" >/etc/hostname
-	hostname -F /etc/hostname
+	if [ x"$hostname" != xeaton-rc3 ]; then
+		echo "$hostname" >/etc/hostname
+		hostname -F /etc/hostname
+	else
+		hostname "eaton-rc3"
+	fi
 	( which hostnamectl 2>/dev/null ) && hostnamectl set-hostname "$hostname" || true
 
 	# Apparently, the first token for a locally available IP address is

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -76,7 +76,9 @@ hostname_setup() {
 	case x"$hostname" in
 		x|xeaton-rc3|xlocalhost*)
 			echo "$0: WARN: Current (or DHCP-suggested) hostname is '$hostname', generating a default MAC-based one instead" >&2
-			hostname="eaton-rc-$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")"
+			hostname_addon="$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")" \
+			&& [ -n "${hostname_addon}" ] && hostname="eaton-rc-${hostname_addon}" && echo "$0: INFO: Generated '$hostname' instead" >&2 \
+			|| echo "$0: WARN: FAILED to generate a hostname based on a MAC address" >&2
 			;;
 	esac
 

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -71,7 +71,8 @@ hostname_setup() {
 
     # Pass the DHCP-suggested name (if any), it wold be applied if nothing
     # is set in /etc/hostname yet, and then saved into the file.
-    fty-hostname-setup "$hostname" "true"
+    interface="$interface" \
+        fty-hostname-setup "$hostname" "true"
 }
 
 ntp_server_restart_do() (

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -78,7 +78,7 @@ hostname_setup() {
 			echo "$0: WARN: Current (or DHCP-suggested) hostname is '$hostname', generating a default MAC-based one instead" >&2
 			hostname_addon="$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")" \
 			&& [ -n "${hostname_addon}" ] && hostname="eaton-rc-${hostname_addon}" && echo "$0: INFO: Generated '$hostname' instead" >&2 \
-			|| echo "$0: WARN: FAILED to generate a hostname based on a MAC address" >&2
+			|| { hostname="eaton-rc3" ; echo "$0: WARN: FAILED to generate a hostname based on a MAC address, fall back to '$hostname'" >&2 ; }
 			;;
 	esac
 

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -81,6 +81,7 @@ hostname_setup() {
 
 	echo "$hostname" >/etc/hostname
 	hostname -F /etc/hostname
+	( which hostnamectl 2>/dev/null ) && hostnamectl set-hostname "$hostname" || true
 
 	# Apparently, the first token for a locally available IP address is
 	# treated as the `hostname --fqdn` if no other ideas are available.

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -70,6 +70,7 @@ hostname_setup() {
 	esac
 	if test -s /etc/hostname; then
 		# Assume the name was already set up to whatever user wanted before
+		# It should then be changed locally
 		return
 	fi
 	case x"$hostname" in

--- a/tools/udhcpc-hook.sh
+++ b/tools/udhcpc-hook.sh
@@ -69,11 +69,14 @@ hostname_setup() {
             ;;
 	esac
 	if test -s /etc/hostname; then
+		# Assume the name was already set up to whatever user wanted
 		return
 	fi
-	if test -z "$hostname"; then
-		hostname=eaton-rc-$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")
-	fi
+	case x"$hostname" in
+		x|xeaton-rc3|xlocalhost*)
+			hostname=eaton-rc-$(ip link show dev "$interface" | sed -rn 's@:@@g; s@.*ether ([0-9a-f]*) .*@\1@p' | tr "abcdef" "ABCDEF")
+			;;
+	esac
 
 	echo "$hostname" >/etc/hostname
 	hostname -F /etc/hostname

--- a/tools/udhcpc-override.sh
+++ b/tools/udhcpc-override.sh
@@ -90,7 +90,17 @@ case "$UDHCPC_OPTS" in
     *hostname*) ;; # Something provided already
     *)  # Give hint about my non-default name
         case x"`hostname`" in
-            x|xeaton-rc3|xlocalhost*) echo "WARNING: Current local host name is '`hostname`' so not pushing it to DHCP" >&2 ;;
+            x|xeaton-rc3|xlocalhost*)
+                echo "WARNING: Current local host name is '`hostname`', trying to find a better name" >&2
+                # Try to generate and apply a MAC-based name, do not save it
+                # yet - might do so through DHCP assignment processing though
+                fty-hostname-setup "" "false"
+            ;;
+        esac
+
+        case x"`hostname`" in
+            x|xeaton-rc3|xlocalhost*)
+                echo "WARNING: Current local host name is '`hostname`', so not pushing it to DHCP" >&2 ;;
             *) UDHCPC_OPTS="$UDHCPC_OPTS -x hostname:`hostname`" ;;
         esac
         ;;

--- a/tools/udhcpc-override.sh
+++ b/tools/udhcpc-override.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2015-2018 Eaton
+# Copyright (C) 2015-2019 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -87,10 +87,12 @@ fi
     UDHCPC_OPTS="$UDHCPC_OPTS_DEFAULT"
 
 case "$UDHCPC_OPTS" in
-    *hostname*) ;;
+    *hostname*) ;; # Something provided already
     *)  # Give hint about my non-default name
-        [ x"`hostname`" != xeaton-rc3 ] && \
-        UDHCPC_OPTS="$UDHCPC_OPTS -x hostname:`hostname`"
+        case x"`hostname`" in
+            x|xeaton-rc3|xlocalhost*) echo "WARNING: Current local host name is '`hostname`' so not pushing it to DHCP" >&2 ;;
+            *) UDHCPC_OPTS="$UDHCPC_OPTS -x hostname:`hostname`" ;;
+        esac
         ;;
 esac
 

--- a/tools/udhcpc-override.sh
+++ b/tools/udhcpc-override.sh
@@ -94,7 +94,8 @@ case "$UDHCPC_OPTS" in
                 echo "WARNING: Current local host name is '`hostname`', trying to find a better name" >&2
                 # Try to generate and apply a MAC-based name, do not save it
                 # yet - might do so through DHCP assignment processing though
-                fty-hostname-setup "" "false"
+                interface="$UDHCPC_IFACE" \
+                    fty-hostname-setup "" "false"
             ;;
         esac
 


### PR DESCRIPTION
This change set evicts our product-intimate host name setup into a separate script and service, so this should not confuse the DHCP client requesting and receiving a bogus hostname (if a reasonable one was not set for some reason by the OS loader).