### PR TITLE
Problem: sometimes slow hosts take ages to fty-db-init (master)

### DIFF
--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -17,6 +17,10 @@ PartOf=bios.target
 # trying to start up indefinitely (e.g. initial boot, untouched for days).
 Type=forking
 User=root
+# Unlimited startup...
+TimeoutStartSec=0
+# More than 90, less than in bios.service
+TimeoutStopSec=100
 # the service shall be considered active even when all its processes exited
 RemainAfterExit=yes
 Restart=always


### PR DESCRIPTION
Solution: disable systemd start timeouts so we do not
half-initialize and then be killed to restart with a
corrupted schema...

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>