### PR TITLE
Revise db-init script

### DIFF
--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2014-2015 Eaton
+# Copyright (C) 2014 - 2019 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -516,6 +516,9 @@ esac
 	exit 2
 
 ensure_root_password || exit $?
+
+# Note that BIOS_DB_INIT is very optional and mostly intended
+# for development. Production code does not set it.
 case "${BIOS_DB_INIT-}" in
 	generate|initialize|flush|init) generate_database; exit $? ;;
 	upgrade|update) upgrade_database; exit $? ;;

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -521,7 +521,7 @@ ensure_root_password || exit $?
 # for development. Production code does not set it.
 case "${BIOS_DB_INIT-}" in
 	generate|initialize|flush|init) generate_database; exit $? ;;
-	upgrade|update) upgrade_database; exit $? ;;
+	upgrade|update) upgrade_database "$@"; exit $? ;;
 esac
 
 # From here on, the mysql client should rely on ~/.my.cnf

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -247,7 +247,7 @@ install_sql_file() {
 	; then
 		echo "Database for 42ity initialization - importing $COMMENT `basename $INITSQL`..."
 		do_mysql < "$INITSQL" || return 1
-		SQLINSTALL_SCHEMA_VERSION="v=`grep_sql_version < "$INITSQL"`." || BIOS_SCHEMA_VERSION_SQL=""
+		SQLINSTALL_SCHEMA_VERSION="v=`grep_sql_version < "$INITSQL"`." || SQLINSTALL_SCHEMA_VERSION=""
 		[ -n "$INSTSQL_DIR" ] && [ -d "$INSTSQL_DIR" ] && \
 			gzip -c < "$INITSQL" > "$INSTSQL_DIR/`basename "$INITSQL"`.$SQLINSTALL_SCHEMA_VERSION$SQLINSTALL_TIMESTAMP.gz"
 		return 0

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -541,6 +541,13 @@ fi
 for F in "$INITSQL_FIRST" \
 	`{ ls -1 "${INITSQL_DIR}"/*.sql | sed 's,^.*/\([^\/]*$\),\1,'; exec_sql_db 'SELECT DISTINCT filename FROM t_bios_schema_version;' ; } | sort | uniq | grep -v "$(basename $INITSQL_FIRST)"` \
 ; do
+	# Note that policy and activity regarding SQL schema files distributed
+	# with the current product vs. files and versions registered in the
+	# database is defined in verify_schema_version(). In particular, it
+	# currently would trigger an import of newly found files that were
+	# not seen before (schema upgrade for newer product version), calling
+	# upgrade_database(), and will complain fatally about changed versions
+	# of files that were already imported before.
 	verify_schema_version "$F" || exit $?
 done
 


### PR DESCRIPTION
Mostly commenting the unclear/forgotten logical points while investigating the script's behavior in case we cosmetically edited SQL files (and kept the version tags) for a newer release. 

Long story short: if the tag was imported earlier, the file will not be reprocessed; if the version tag got changed, the script will complain and die; so any editions in a re-release may happen only for cosmetic purposes and should not actually change the schema compared to an older release of this SQL file name: in case of upgrades, either the change will not be seen (if version is unmodified), or would abort the fty-db-init.service (if version is modified). Any such schema changes must arrive in subsequent (alphabetically) filenames with payload set in stone after an end-user release.

There is a couple of functional fixes, but they are for situations that should not happen in a healthy production run, so nothing required for an imminent release-branch backport.