### PR TITLE
Problem: Not sure if fty-db-ready appears at right moment

### DIFF
--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -33,8 +33,8 @@ EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
-ExecStart=@libexecdir@/@PACKAGE@/db-init
-ExecStartPost=/usr/bin/touch /var/run/fty-db-ready
+ExecStart=@libexecdir@/@PACKAGE@/db-init --db-ready-file /var/run/fty-db-ready
+#ExecStartPost=/usr/bin/touch /var/run/fty-db-ready
 ExecStop=-/bin/rm -f /var/run/fty-db-ready
 ExecStopPost=/bin/dash -c "/bin/systemctl stop -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundTo fty-db-init.service | cut -d= -f2 | tr ' ' '\\n' | egrep -v '^(bios|fty)\.(service|target)$')"
 

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -487,6 +487,20 @@ trap_exit() {
 
 trap 'trap_exit' 0 1 2 3 15
 
+DB_READY_FILE=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--db-ready-file)
+			shift
+			case "$1" in
+				/*)	DB_READY_FILE="$1" ;;
+				*)	echo "DB_READY_FILE must be a fully qualified path" >&2 ; exit 1 ;;
+			esac
+			;;
+		*) echo "Unsupported argument, ignored: $1" >&2 ;;
+	shift
+done
+
 case "$INSTSQL_DIR" in
 	/*) [ -d "$INSTSQL_DIR" ] || { \
 			echo "Creating INSTSQL_DIR='$INSTSQL_DIR' to save copies of applied SQL files..."; \
@@ -540,6 +554,11 @@ for F in "$INITSQL_FIRST" \
 ; do
 	verify_schema_version "$F" || exit $?
 done
+
+if [ -n "$DB_READY_FILE" ] ; then
+	echo "Trying to touch the '$DB_READY_FILE' to mark completion of init/verification of DB schema, database is ready to use by IPM applications"
+	mkdir -p "`dirname "$DB_READY_FILE"`" && touch "$DB_READY_FILE"
+fi
 
 echo "Database for 42ity - found and deemed sufficient"
 exit 0


### PR DESCRIPTION
Solution: Move the touching into the script (optional, to let devs
still use it safely) and let the service still define the path used

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>