### PR TITLE
obs/preinstallimage-bios.sh.in : try to pre-disable mysql(d) before…

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -526,8 +526,12 @@ cp /usr/share/fty/examples/config/malamute/malamute.cfg /etc/malamute
 
 # Enable 42ity services (distributed as a systemd preset file)
 if [ "${OSIMAGE_DISTRO}" = "Debian_10.0" ]; then
+    /bin/systemctl disable mysql.service || true
+    /bin/systemctl disable mysqld.service || true
+    /bin/systemctl disable mariadb.service || true
     /bin/systemctl mask mysql.service || true
     /bin/systemctl mask mysqld.service || true
+    /bin/systemctl mask mariadb.service || true
 fi
 
 /bin/systemctl preset-all


### PR DESCRIPTION
…trying to pre-mask them away. And mariadb too, we override via fty-db-engine anyway.