### PR TITLE
[DNMY] Proposed workaround for PQSWPRG-7176

### DIFF
--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -9,6 +9,7 @@ Type=simple
 Restart=always
 User=root
 Group=root
+UMask=0000
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-@prefix@/share/fty/etc/default/fty

--- a/tools/tntnet-ExecStartPre.sh.in
+++ b/tools/tntnet-ExecStartPre.sh.in
@@ -1,7 +1,6 @@
 #!/bin/bash
-
 #
-# Copyright (C) 2014-2019 Eaton
+# Copyright (C) 2014-2020 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/tntnet-ExecStartPre.sh.in
+++ b/tools/tntnet-ExecStartPre.sh.in
@@ -45,6 +45,13 @@ cat /etc/tntnet/"$INST".d/*.xml > /etc/tntnet/"$INST".xml
 echo "Make sure we have _bios-script password..."
 @datadir@/@PACKAGE@/scripts/_bios-script.sh
 
+OS_VERSION=`cat /etc/debian_version | sed 's/\..*//'`
+if [ $OS_VERSION -ge 10 ]; then
+  echo "Change tntnet user to root in /etc/tntnet/$INST.xml"
+  USER="root"
+  sed -i "s,<user>\(.*\)<,<user>$USER<,g" /etc/tntnet/"$INST".xml
+fi
+
 WWW_USER="`grep '<user>' /etc/tntnet/"$INST".xml  | sed 's,^.*>\(.*\)<.*$,\1,'`" \
     && [ -n "$WWW_USER" ] \
     || WWW_USER="www-data"


### PR DESCRIPTION
- syscall setresuid fails on Debian 10, preventing login
- temporary fix is to run tntnet as root (only for Debian 10 image)

Signed-off-by: Mauro Guerrera
<mauroguerrera@eaton.com>