### PR TITLE
Alleviate ipc-meta-setup timeouts and make them more debuggable

### DIFF
--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -37,7 +37,7 @@ BASEDIR="$(dirname $(readlink -f ${0}))"
 SETUPDIR=/var/lib/fty/ipc-meta-setup/
 
 die () {
-    echo "FATAL: " "${@}" >&2
+    echo "FATAL: " "`date -u`: " "${@}" >&2
     exit 1
 }
 
@@ -54,7 +54,7 @@ trap 'META_RES=$? ; echo "$0: Aborting due to SIGINT" >&2 ; exit $META_RES;'  2
 trap 'META_RES=$? ; echo "$0: Aborting due to SIGQUIT" >&2 ; exit $META_RES;' 3
 trap 'META_RES=$? ; echo "$0: Aborting due to SIGABRT" >&2 ; exit $META_RES;' 6
 
-echo "STARTING: $0 for scriptlets under ${BASEDIR}"
+echo "STARTING: $0 for scriptlets under ${BASEDIR}, at `date -u`..."
 ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 
     # We generally run scripts once, to set up a newly deployed system,
@@ -78,11 +78,11 @@ ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
         [ "$EVERY_TIME" = "yes" ] || continue
     fi
 
-    echo "APPLY: running ${SCRIPT_NAME}..."
+    echo "APPLY: running ${SCRIPT_NAME} at `date -u`..."
     ${SCRIPT} || die "${SCRIPT} failed with exit-code $?, not proceeding with other scripts"
     touch "${SETUPDIR}/${SCRIPT_NAME}.done" && \
-    echo "APPLIED: successfully ran ${SCRIPT_NAME}"
+    echo "APPLIED: successfully ran ${SCRIPT_NAME}, finished at `date -u`..."
 
 done || die "Something in $0 failed, aborting"
 
-echo "COMPLETED: successfully ran $0"
+echo "COMPLETED: successfully ran $0, finished at `date -u`..."

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -48,6 +48,12 @@ mkdir -p "${SETUPDIR}"
 # Make sure scripts do not leave occasional traces in unexpected places
 cd /tmp || die "No /tmp!"
 
+# Log the reason of untimely demise for typical causes (e.g. systemd timeout)...
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGTERM" >&2 ; exit $META_RES;' 15
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGINT" >&2 ; exit $META_RES;'  2
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGQUIT" >&2 ; exit $META_RES;' 3
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGABRT" >&2 ; exit $META_RES;' 6
+
 echo "STARTING: $0 for scriptlets under ${BASEDIR}"
 ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -79,7 +79,12 @@ ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
     fi
 
     echo "APPLY: running ${SCRIPT_NAME} at `date -u`..."
-    ${SCRIPT} || die "${SCRIPT} failed with exit-code $?, not proceeding with other scripts"
+    if [ -x "${SCRIPT}" ]; then
+        ${SCRIPT}
+    else
+        echo "WARNING: ${SCRIPT_NAME} is not executable by itself, sub-shelling to run it. Its original shebang is: `head -1 "${SCRIPT}" | egrep '^\#\!\/'`" >&2
+        ( . ${SCRIPT} )
+    fi || die "${SCRIPT} failed with exit-code $?, not proceeding with other scripts"
     touch "${SETUPDIR}/${SCRIPT_NAME}.done" && \
     echo "APPLIED: successfully ran ${SCRIPT_NAME}, finished at `date -u`..."
 

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -80,10 +80,10 @@ ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 
     echo "APPLY: running ${SCRIPT_NAME} at `date -u`..."
     if [ -x "${SCRIPT}" ]; then
-        ${SCRIPT}
+        "${SCRIPT}"
     else
         echo "WARNING: ${SCRIPT_NAME} is not executable by itself, sub-shelling to run it. Its original shebang is: `head -1 "${SCRIPT}" | egrep '^\#\!\/'`" >&2
-        ( . ${SCRIPT} )
+        ( . "${SCRIPT}" )
     fi || die "${SCRIPT} failed with exit-code $?, not proceeding with other scripts"
     touch "${SETUPDIR}/${SCRIPT_NAME}.done" && \
     echo "APPLIED: successfully ran ${SCRIPT_NAME}, finished at `date -u`..."

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-#   Copyright (c) 2014-2017 Eaton
+#   Copyright (c) 2014 - 2020 Eaton
 #
 #   This file is part of the Eaton 42ity project.
 #
@@ -33,6 +33,7 @@ TZ=UTC
 export LC_ALL LANG TZ
 
 BASEDIR="$(dirname $(readlink -f ${0}))"
+# TODO: Use configure.ac templated variables?
 SETUPDIR=/var/lib/fty/ipc-meta-setup/
 
 die () {
@@ -47,6 +48,7 @@ mkdir -p "${SETUPDIR}"
 # Make sure scripts do not leave occasional traces in unexpected places
 cd /tmp || die "No /tmp!"
 
+echo "STARTING: $0 for scriptlets under ${BASEDIR}"
 ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 
     # We generally run scripts once, to set up a newly deployed system,
@@ -72,6 +74,9 @@ ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 
     echo "APPLY: running ${SCRIPT_NAME}..."
     ${SCRIPT} || die "${SCRIPT} failed with exit-code $?, not proceeding with other scripts"
-    touch "${SETUPDIR}/${SCRIPT_NAME}.done"
+    touch "${SETUPDIR}/${SCRIPT_NAME}.done" && \
+    echo "APPLIED: successfully ran ${SCRIPT_NAME}"
 
-done
+done || die "Something in $0 failed, aborting"
+
+echo "COMPLETED: successfully ran $0"

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -49,10 +49,10 @@ mkdir -p "${SETUPDIR}"
 cd /tmp || die "No /tmp!"
 
 # Log the reason of untimely demise for typical causes (e.g. systemd timeout)...
-trap 'META_RES=$? ; echo "$0: Aborting due to SIGTERM" >&2 ; exit $META_RES;' 15
-trap 'META_RES=$? ; echo "$0: Aborting due to SIGINT" >&2 ; exit $META_RES;'  2
-trap 'META_RES=$? ; echo "$0: Aborting due to SIGQUIT" >&2 ; exit $META_RES;' 3
-trap 'META_RES=$? ; echo "$0: Aborting due to SIGABRT" >&2 ; exit $META_RES;' 6
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGTERM at `date -u`" >&2 ; exit $META_RES;' 15
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGINT  at `date -u`" >&2 ; exit $META_RES;'  2
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGQUIT at `date -u`" >&2 ; exit $META_RES;' 3
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGABRT at `date -u`" >&2 ; exit $META_RES;' 6
 
 echo "STARTING: $0 for scriptlets under ${BASEDIR}, at `date -u`..."
 ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -13,5 +13,12 @@ ExecStart = @prefix@/share/fty/setup/ipc-meta-setup.sh
 RemainAfterExit = yes
 PrivateTmp = yes
 
+# Normally this service should start very quickly; however on congested
+# hypervisors with slower I/O it tends to be killed by systemd after 90s
+# and then by design blocks the rest of product startup as the system is
+# not in a known usable state.
+# Try to avoid this situation by allowing a (still finite) larger timeout.
+TimeoutStartSec=300
+
 [Install]
 RequiredBy=network.target systemd-tmpfiles-setup.service


### PR DESCRIPTION
While the likely root cause of failures seen in tests was the load on hypervisor or NAS backing the test VMs, to the point that probably ipc-meta-setup was killed by systemd (some other services including the journal were, due to lack of logs the guess is inconclusive however), we can try to tackle it by:
* bumping the systemd timeout (discussed to not make it infinite at this time);
* improving logging for death by certain signals;
* improving logging of progress (began/finished some steps) to simplify postmortems.
