### PR TITLE
Alleviate ipc-meta-setup timeouts and make them more debuggable (really to 2.1.0)

### DIFF
--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -48,6 +48,12 @@ mkdir -p "${SETUPDIR}"
 # Make sure scripts do not leave occasional traces in unexpected places
 cd /tmp || die "No /tmp!"
 
+# Log the reason of untimely demise for typical causes (e.g. systemd timeout)...
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGTERM" >&2 ; exit $META_RES;' 15
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGINT" >&2 ; exit $META_RES;'  2
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGQUIT" >&2 ; exit $META_RES;' 3
+trap 'META_RES=$? ; echo "$0: Aborting due to SIGABRT" >&2 ; exit $META_RES;' 6
+
 echo "STARTING: $0 for scriptlets under ${BASEDIR}"
 ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 

--- a/setup/ipc-meta-setup.sh
+++ b/setup/ipc-meta-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-#   Copyright (c) 2014-2017 Eaton
+#   Copyright (c) 2014 - 2020 Eaton
 #
 #   This file is part of the Eaton 42ity project.
 #
@@ -33,6 +33,7 @@ TZ=UTC
 export LC_ALL LANG TZ
 
 BASEDIR="$(dirname $(readlink -f ${0}))"
+# TODO: Use configure.ac templated variables?
 SETUPDIR=/var/lib/fty/ipc-meta-setup/
 
 die () {
@@ -47,6 +48,7 @@ mkdir -p "${SETUPDIR}"
 # Make sure scripts do not leave occasional traces in unexpected places
 cd /tmp || die "No /tmp!"
 
+echo "STARTING: $0 for scriptlets under ${BASEDIR}"
 ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 
     # We generally run scripts once, to set up a newly deployed system,
@@ -72,6 +74,9 @@ ls -1 "${BASEDIR}"/[0-9]*.sh | sort | while read SCRIPT; do
 
     echo "APPLY: running ${SCRIPT_NAME}..."
     ${SCRIPT} || die "${SCRIPT} failed with exit-code $?, not proceeding with other scripts"
-    touch "${SETUPDIR}/${SCRIPT_NAME}.done"
+    touch "${SETUPDIR}/${SCRIPT_NAME}.done" && \
+    echo "APPLIED: successfully ran ${SCRIPT_NAME}"
 
-done
+done || die "Something in $0 failed, aborting"
+
+echo "COMPLETED: successfully ran $0"

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -13,5 +13,12 @@ ExecStart = @prefix@/share/fty/setup/ipc-meta-setup.sh
 RemainAfterExit = yes
 PrivateTmp = yes
 
+# Normally this service should start very quickly; however on congested
+# hypervisors with slower I/O it tends to be killed by systemd after 90s
+# and then by design blocks the rest of product startup as the system is
+# not in a known usable state.
+# Try to avoid this situation by allowing a (still finite) larger timeout.
+TimeoutStartSec=300
+
 [Install]
 RequiredBy=network.target systemd-tmpfiles-setup.service


### PR DESCRIPTION
Replay the botch of #393 wrongly targeted