### PR TITLE
Remove nut.target from multi-user.target, to avoid breaking

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -725,6 +725,15 @@ BindsTo=fty-license-accepted.service
 After=fty-license-accepted.service
 EOF
 
+# Remove nut.target from multi-user.target, to avoid breaking
+# the fty-license-accepted Requirement on multi-user.target.
+# To achieve this, simply set WantedBy to empty
+mkdir -p /lib/systemd/system/nut.target.d
+cat > /lib/systemd/system/nut.target.d/fty.conf  << EOF
+[Install]
+WantedBy=
+EOF
+
 # Disable fty-license-accepted, before the actual EULA acceptance
 # to avoid flooding console / Welcome screen
 # It will be activated by fty-license-accepted.path

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -715,21 +715,21 @@ case "$IMGTYPE" in
         ;;
 esac
 
-# Bind nut-server actual startup to EULA acceptance
-# to avoid flooding console / Welcome screen
 mkdir -p /etc/systemd/system/nut-server.service.d
 cat > /etc/systemd/system/nut-server.service.d/fty.conf  << EOF
+# Bind nut-server actual startup to EULA acceptance
+# to avoid flooding console / Welcome screen
 [Unit]
 Requires=network.target fty-license-accepted.service
 BindsTo=fty-license-accepted.service
 After=fty-license-accepted.service
 EOF
 
+mkdir -p /lib/systemd/system/nut.target.d
+cat > /lib/systemd/system/nut.target.d/fty.conf  << EOF
 # Remove nut.target from multi-user.target, to avoid breaking
 # the fty-license-accepted Requirement on multi-user.target.
 # To achieve this, simply set WantedBy to empty
-mkdir -p /lib/systemd/system/nut.target.d
-cat > /lib/systemd/system/nut.target.d/fty.conf  << EOF
 [Install]
 WantedBy=
 EOF


### PR DESCRIPTION
the fty-license-accepted Requirement on multi-user.target

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>