### PR TITLE
Problem: fty-license-accepted.service fails to ExecStartPost (2.1.0)

### DIFF
--- a/systemd/fty-license-accepted.service
+++ b/systemd/fty-license-accepted.service
@@ -23,7 +23,7 @@ ExecStart=/bin/dash -c "while ! /usr/bin/test -s /var/lib/fty/fty-eula/license ;
 ExecStartPost=/bin/dash -c "/usr/libexec/fty/disable-root-account"
 ExecStartPost=-/bin/systemctl start --no-block bios.service
 ExecStartPost=/bin/dash -c "/usr/bin/bmsg publish eula ACCEPTED"
-ExecStartPost=/bin/dash -c "/bin/systemctl start --no-block -- $(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundBy fty-license-accepted.service | cut -d= -f2 | sort | uniq | tr '\n' ' ')"
+ExecStartPost=/bin/dash -c "UNITS=\"$(/bin/systemctl show -p WantedBy -p RequiredBy -p BoundBy -p RequisiteOf %n | cut -d= -f2 | sort | uniq | tr '\n' ' ' | sed -e 's,^ *,,' -e 's, *$,,')\"; if [ -n \"$UNITS\" ] ; then /bin/systemctl start --no-block -- $UNITS ; else echo 'No units seem to directly depend on %n to tickle them into starting' ; fi"
 
 [Install]
 WantedBy=bios.target


### PR DESCRIPTION
Analysis: After recent dependency changes, the listing of
dependent units to start came up empty where we want to tickle
them to start up, and so systemctl errored out and then
fty-license-accepted.service stopped soon after starting.
As a result, units that (newly) declared they are PartOf
fty-license-accepted.service, like fty-db-engine, were stopped.

Solutions:
* add RequisiteOf for completeness
* cache the list of found units into a variable, and only
  call systemctl if the list is not empty, or visibly log
  otherwise (a bit of future-proofness).

TODO: port this approach to other units that stop/start stuff

One idea was to also add "-p ConsistsOf" into the query of
services to tickle, but this is not semantically correct
for causing start-ups.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Replay of master's #409 