### PR TITLE
Hotfix DB service startup occasionally failing after EULA

### DIFF
--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -27,10 +27,10 @@ RestartSec=5
 TimeoutStartSec=0
 # More than 90, less than in bios.service
 TimeoutStopSec=100
-ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
 # Hack to work around systemd deficiencies, where fty-license-accepted.path+service are not enough
 # Better ugly than sorry (with DB beginning to start, then getting killed by newly realized dependency unit states, and ending up with corrupted DB files rarely)
 ExecStartPre=/bin/dash -c "test -f /var/lib/fty/fty-eula/license"
+ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
 ExecStartPre=/bin/dash -c "if [ -d /var/lib/mysql ] ; then /bin/chown -R mysql:mysql /var/lib/mysql ; fi"
 # If the database begins starting and systemd decides it should not,
 # cache the request to stop if possible and only do so after starting -

--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -117,7 +117,15 @@ if [[ "$SYSTEMCTL_COALESCE_INITIAL" = no ]] ; then
     echo "INFO: `date -u`: enable and start fty-db-engine"
     sudo ${SYSTEMCTL} unmask fty-db-engine || die "Unmasking fty-db-engine failed ($?)"
     sudo ${SYSTEMCTL} enable fty-db-engine || die "Enabling fty-db-engine failed ($?)"
-    sudo ${SYSTEMCTL} start fty-db-engine || die "Starting fty-db-engine failed ($?)"
+    # Try twice, to avoid the possibility that an attempt to start the
+    # fty-db-engine.service did begin before, due to external circumstances,
+    # and this call to systemctl would return failure of that run (e.g. the
+    # license file missing at the point that copy of startup was evaluated).
+    # Note that by current product layout, only fty-db-engine is expected to
+    # fall into this trap.
+    sudo ${SYSTEMCTL} start fty-db-engine \
+        || (sleep 1; sudo ${SYSTEMCTL} start fty-db-engine) \
+        || die "Starting fty-db-engine failed ($?)"
 
     echo "INFO: `date -u`: enable and start fty-db-init"
     sudo ${SYSTEMCTL} enable fty-db-init || die "Enabling fty-db-init failed ($?)"
@@ -137,8 +145,10 @@ else
 
     sleep 3
 
+    # See comment above about trying to start twice
     echo "INFO: `date -u`: start core database-related services"
     sudo ${SYSTEMCTL} start fty-license-accepted.path fty-license-accepted.service fty-db-engine.service fty-db-init.service \
+        || (sleep 1; sudo ${SYSTEMCTL} start fty-license-accepted.path fty-license-accepted.service fty-db-engine.service fty-db-init.service) \
         || die "Starting a core database-related service failed ($?)"
 fi
 


### PR DESCRIPTION
Educated guess from reading the systemd journal:

After EULA acceptance, the database did not come up, so the wizard errored out. It seems that the scripted processing got caught into the time range between the regular systemd retries to start fty-db-engine, so that a copy was running started before the script that eventually found in its ExecStartPre the license file to not exist at that moment, and another copy "started" (or rather "told to start" due to systemd properly avoiding running several copies of the same service instance) by virtue of having fty-license-accepted.service finally active, and another by the explicit fallback start in the script.

In the end, systemctl called from the script probably returns the failure to start which originated from the service instance startup attempted before the scripted call to systemctl was started and eventually failed due to lack of license file. And this opposes the original expectation we had during that script development, that this systemctl call would be the first attempt to start the database. While the proper fix would be to actually make this happen in such order, a viable workaround for randomly failed EULA wizards can be to retry fty-db-engine startup if it fails once.

Also it is clearer for logging and faster for looping with less system load, to first check for the EULA file and then do any other logic of this unit's startup.