### PR TITLE
Introduce fty-db-engine-pre to offload killing of competing mysql implementation instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,8 @@ systemd/ipc-meta-setup.service
 systemd/fty-db-init.service
 !systemd/fty-db-engine.service.in
 systemd/fty-db-engine.service
+!systemd/fty-db-engine-pre.service.in
+systemd/fty-db-engine-pre.service
 !systemd/fty-tntnet@.service.in
 systemd/fty-tntnet@.service
 !systemd/fty-envvars.service.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -326,6 +326,7 @@ SYSTEMD_UNITS_EXTRA += \
 # to enable a "tntnet@bios.service" instance specifically.
 # And also some of the timer units and implementations below
 SYSTEMD_UNITS_TARGET_BIOS += \
+                        fty-db-engine-pre.service \
                         fty-db-engine.service \
                         fty-db-init.service
 

--- a/configure.ac
+++ b/configure.ac
@@ -347,6 +347,7 @@ AC_CONFIG_FILES([
         systemd/biostimer-compress-logs.service
         systemd/biostimer-loghost-rsyslog-netconsole.service
         systemd/biostimer-verify-fs.service
+        systemd/fty-db-engine-pre.service
         systemd/fty-db-engine.service
         systemd/fty-db-init.service
         systemd/fty-envvars.service

--- a/systemd/fty-db-engine-pre.service.in
+++ b/systemd/fty-db-engine-pre.service.in
@@ -1,0 +1,25 @@
+# WARNING: This unit is intended for systems or containers dedicated as
+# 42ity execution environments. It disables any existing MySQL server.
+# We offload killing of competing mysql implementation instances to where
+# its failure would not block this critical unit. Sometimes executions
+# of systemctl from units block...
+
+[Unit]
+Description=Prepare for MySQL server for 42ity usage (remove competitors)
+Wants=basic.target network.target
+Requisite=fty-license-accepted.service
+After=basic.target network.target fty-license-accepted.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=on
+User=root
+RestartSec=5
+# Hack to work around systemd deficiencies, where fty-license-accepted.path+service are not enough
+# Better ugly than sorry (with DB beginning to start, then getting killed by newly realized dependency unit states, and ending up with corrupted DB files rarely)
+ExecStartPre=/bin/dash -c "test -f @ftydatadir@/fty-eula/license"
+ExecStart=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
+
+# No [Install] section for directly defined dependency calls only
+### [Install]
+### WantedBy=fty-db-engine.target

--- a/systemd/fty-db-engine-pre.service.in
+++ b/systemd/fty-db-engine-pre.service.in
@@ -18,7 +18,7 @@ User=root
 TimeoutStartSec=15
 # Hack to work around systemd deficiencies, where fty-license-accepted.path+service are not enough
 # Better ugly than sorry (with DB beginning to start, then getting killed by newly realized dependency unit states, and ending up with corrupted DB files rarely)
-ExecStartPre=/bin/dash -c "test -f @ftydatadir@/fty-eula/license"
+ExecStartPre=/bin/dash -c "test -f /var/lib/fty/fty-eula/license"
 ExecStart=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do [ xactive != x\"`/bin/systemctl is-active $S`\" ] || /bin/systemctl stop $S ; ( [ xmasked = x\"`/bin/systemctl is-enabled $S`\" ] || [ xenabled = x\"`/bin/systemctl is-enabled $S`\" ] ) || /bin/systemctl disable $S ; [ xLoadState=masked = x\"`/bin/systemctl show -p LoadState $S`\" ] || /bin/systemctl mask $S ; done ; for S in mysql.service mysqld.service mariadb.service ; do [ xactive != x\"`/bin/systemctl is-active $S`\" ] || echo \"WARNING: competitor $S of fty-db-engine.service is still active\" ; done"
 
 # No [Install] section for directly defined dependency calls only

--- a/systemd/fty-db-engine-pre.service.in
+++ b/systemd/fty-db-engine-pre.service.in
@@ -19,7 +19,7 @@ TimeoutStartSec=15
 # Hack to work around systemd deficiencies, where fty-license-accepted.path+service are not enough
 # Better ugly than sorry (with DB beginning to start, then getting killed by newly realized dependency unit states, and ending up with corrupted DB files rarely)
 ExecStartPre=/bin/dash -c "test -f @ftydatadir@/fty-eula/license"
-ExecStart=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
+ExecStart=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do [ xactive != x\"`/bin/systemctl is-active $S`\" ] || /bin/systemctl stop $S ; ( [ xmasked = x\"`/bin/systemctl is-enabled $S`\" ] || [ xenabled = x\"`/bin/systemctl is-enabled $S`\" ] ) || /bin/systemctl disable $S ; [ xLoadState=masked = x\"`/bin/systemctl show -p LoadState $S`\" ] || /bin/systemctl mask $S ; done ; for S in mysql.service mysqld.service mariadb.service ; do [ xactive != x\"`/bin/systemctl is-active $S`\" ] || echo \"WARNING: competitor $S of fty-db-engine.service is still active\" ; done"
 
 # No [Install] section for directly defined dependency calls only
 ### [Install]

--- a/systemd/fty-db-engine-pre.service.in
+++ b/systemd/fty-db-engine-pre.service.in
@@ -14,7 +14,8 @@ After=basic.target network.target fty-license-accepted.service
 Type=oneshot
 RemainAfterExit=on
 User=root
-RestartSec=5
+#RestartSec=5
+TimeoutStartSec=15
 # Hack to work around systemd deficiencies, where fty-license-accepted.path+service are not enough
 # Better ugly than sorry (with DB beginning to start, then getting killed by newly realized dependency unit states, and ending up with corrupted DB files rarely)
 ExecStartPre=/bin/dash -c "test -f @ftydatadir@/fty-eula/license"

--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -13,6 +13,12 @@ Requires=fty-license-accepted.path
 After=basic.target network.target fty-license-accepted.service
 PartOf=bios.target fty-license-accepted.service
 
+# Offload killing of competing mysql implementation instances to where
+# its failure would not block this critical unit. Sometimes executions
+# of systemctl from units block...
+Wants=fty-db-engine-pre.service
+After=fty-db-engine-pre.service
+
 [Service]
 Type=forking
 Restart=always
@@ -30,7 +36,6 @@ TimeoutStopSec=100
 # Hack to work around systemd deficiencies, where fty-license-accepted.path+service are not enough
 # Better ugly than sorry (with DB beginning to start, then getting killed by newly realized dependency unit states, and ending up with corrupted DB files rarely)
 ExecStartPre=/bin/dash -c "test -f /var/lib/fty/fty-eula/license"
-ExecStartPre=/bin/dash -c "for S in mysql.service mysqld.service mariadb.service ; do for A in stop disable mask ; do /bin/systemctl $A $S || true ; done; done"
 ExecStartPre=/bin/dash -c "if [ -d /var/lib/mysql ] ; then /bin/chown -R mysql:mysql /var/lib/mysql ; fi"
 # If the database begins starting and systemd decides it should not,
 # cache the request to stop if possible and only do so after starting -


### PR DESCRIPTION
More arcane systemd magic to combat issues that should not exist in the first place.

Per internal discussion:

The symptoms I have accumulated so far is that we have some units, including fty-db-engine.service and fty-license-accepted.service (and wrapper bios/ipm2/… services for same-named targets) that manipulate other unit states via systemd in their ExecStartPre lines. Sometimes, when systemd processes this unit’s startup, it just loops executing this line endlessly, and nothing seems to be able to kill this “activating” unit except a “reboot -f”. But this is the service definition we had for years and never saw (or noticed?) such issues, until very recently, so maybe something came in through recent upstream Debian changes. I’ve also asked on systemd IRC, and they confirmed that units manipulating other units directly via systemctl is not an invalid arrangement (although… we mostly had it appear as workaround because some “valid arrangements” expected of service dependency definitions did not work for us, or not reliably, in practice).

I have a potential fix for this situation, offloading the problematic line from fty-db-engine.service into a new fty-db-engine-pre.service that it “Wants+After” (so even if fty-db-engine.service loops trying all that, it should not be fatal for actual DB startup… hopefully… maybe should not have “After” there). In the few image boots I ran so far, I had not seen this offloader of systemctl fail though. But I guess potentially it is as reliable or faulty as the original setup.