### PR TITLE
Improve packages listing match and avoid missing packages

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -1020,7 +1020,7 @@ while IFS=';' read SOURCE_PKG PKG_VERSION CURRENT_PKG
 do
    CURRENT_PKG="`echo ${CURRENT_PKG} | cut -d':' -f1`"
    PKG_VERSION="`echo ${PKG_VERSION} | cut -d':' -f2`"
-   grep -q "${SOURCE_PKG};" "${CSV_FILE_PATH}" || \
+   grep -q "^${SOURCE_PKG};" "${CSV_FILE_PATH}" || \
    if [ $? -eq 1 ]; then
       echo "${SOURCE_PKG};${PKG_VERSION};/legal/${CURRENT_PKG}/copyright" 2>/dev/null >> "${CSV_FILE_PATH}"
       [ ! -f "/usr/share/doc/${CURRENT_PKG}/copyright" ] && echo "Missing ${CURRENT_PKG}/copyright file!"


### PR DESCRIPTION
When generating the packages list, for the Legal Information display,
ensure that we match the current package, and not just one ending with
the same name, to avoid missing packages from the list

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit a0fd3b9afc1f338b5a431c02137b22a73bbd1dd9)