### PR TITLE
Introduce fty-monitor-unlock.service and pre-lock monitor user until …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -319,6 +319,7 @@ SYSTEMD_UNITS_LOWLEVEL += \
 SYSTEMD_UNITS_EXTRA += \
                         fty-license-accepted.path \
                         fty-logrotate.service \
+                        fty-monitor-unlock.service \
                         wd_keepalive@.service
 
 # These service-units are PartOf and WantedBy the "bios.target"

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -131,6 +131,10 @@ EOF
 fi
 mkdir -p /home/monitor && chown monitor:bios-dash /home/monitor
 
+# Do not let monitor login on first boot, it will be unlocked
+# later - by fty-monitor-unlock.service after EULA wizard
+passwd -l monitor
+
 # _bios-script user - special user allowing us to call REST API from scripts
 useradd -m _bios-script -N -g bios-admin -G sasl -s /usr/sbin/nologin
 

--- a/systemd/fty-monitor-unlock.service
+++ b/systemd/fty-monitor-unlock.service
@@ -1,9 +1,13 @@
 [Unit]
 Description=Unlock the monitor account after accepting EULA
-# Enable FLA... once, do not keep retrying if EULA is not accepted yet
-Wants=fty-license-accepted.service
-Requisite=fty-license-accepted.service
-After=fty-license-accepted.service
+
+# Run the payload after EULA is not accepted and there may
+# be something to see on the dashboard. And not too early
+# for a chance to interrupt first initialization somehow.
+Wants=fty-asset.service
+Requisite=fty-asset.service
+After=fty-asset.service
+
 PartOf=bios.target
 
 [Service]

--- a/systemd/fty-monitor-unlock.service
+++ b/systemd/fty-monitor-unlock.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Unlock the monitor account after accepting EULA
+# Enable FLA... once, do not keep retrying if EULA is not accepted yet
+Wants=fty-license-accepted.service
+Requisite=fty-license-accepted.service
+After=fty-license-accepted.service
+PartOf=bios.target
+
+[Service]
+Type=oneshot
+Restart=no
+User=root
+ExecStart=/usr/bin/passwd -u monitor
+ExecStart=/bin/sh -c "/bin/systemctl disable --no-ask-password %n ; /bin/systemctl mask --no-ask-password %n"
+
+[Install]
+WantedBy=bios.target


### PR DESCRIPTION
…EULA wizard is passed

Note: the choice of FLA as the allowing trigger to re-enable monitor is arbitrary; other reasonable options are usable database or running fty-asset (so a chance to see something useful on the dashboard... and not intervene for possible unpretty views or worse while things are spawned)