### PR TITLE
Verify-fs fixes (master)

### DIFF
--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -101,6 +101,9 @@ fi
 [[ -d ${IMAGES} ]] || \
     die "Can't find images ${IMAGES}"
 
+PROBLEMCOUNT=0
+MISSINGCOUNT=0
+
 ## 1.) Verify the images
 pushd "${IMAGES}" >/dev/null
 for ROOTFS in *.squashfs; do
@@ -110,9 +113,11 @@ for ROOTFS in *.squashfs; do
             log "Good integrity of ${ROOTFS}, MD5 checksum is valid"
         else
             log "Bad integrity of ${ROOTFS}, MD5 checksum is not valid"
+            PROBLEMCOUNT=$(($PROBLEMCOUNT+1))
         fi
     else
         log "Missing MD5 checksum file: '${ROOTFS}.md5'"
+        MISSINGCOUNT=$(($MISSINGCOUNT+1))
     fi
 
     if [ -s "${ROOTFS}.sha256" ] ; then
@@ -129,21 +134,27 @@ for ROOTFS in *.squashfs; do
                             log "Image signature is valid for ${ROOTFS}"
                         else
                             log "Image signature is invalid for ${ROOTFS}"
+                            PROBLEMCOUNT=$(($PROBLEMCOUNT+1))
                         fi
                     else
                         log "Manifest signature not found for ${ROOTFS}"
+                        MISSINGCOUNT=$(($MISSINGCOUNT+1))
                     fi
                 else
                     log "Manifest sha256 hash does not match with the sha256 hash for ${ROOTFS}"
+                    PROBLEMCOUNT=$(($PROBLEMCOUNT+1))
                 fi
             else
                 log "Manifest not found for ${ROOTFS}"
+                MISSINGCOUNT=$(($MISSINGCOUNT+1))
             fi
         else
             log "Bad integrity of ${ROOTFS}, SHA256 checksum is not valid"
+            PROBLEMCOUNT=$(($PROBLEMCOUNT+1))
         fi
     else
         log "Missing SHA256 checksum file: '${ROOTFS}.sha256'"
+        MISSINGCOUNT=$(($MISSINGCOUNT+1))
     fi
 
 done
@@ -157,5 +168,12 @@ cat_default | while read LINE; do
     [[ -d "${OVERLAY}/${TREE}" ]] || continue
 
     is_tree_empty "${OVERLAY}/${TREE}" ${EXCLUDES//:/ } || \
-        log "${OVERLAY}/${TREE} contains suspicious files."
+        { log "${OVERLAY}/${TREE} contains suspicious files." ; PROBLEMCOUNT=$(($PROBLEMCOUNT+1)); }
 done
+
+if [ "$PROBLEMCOUNT" = 0 ] ; then
+    logboth "SUCCESS: Completed verify-fs at `date -u` with no problems to report (and $MISSINGCOUNT inspected sources were missing)"
+else
+    logboth "FAILED: Completed verify-fs at `date -u` with $PROBLEMCOUNT problems to report (and $MISSINGCOUNT inspected sources were missing)"
+#    exit 1
+fi

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -32,8 +32,17 @@ IMAGES=@IMAGES_PATH@
 JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
 get_a_string_arg() { "$JSONSH" --get-string "$1" ; }
 
-die () {
+syslogger () {
+    /usr/bin/logger -i -p security.err -t "verify-fs" "${@}"
+}
+
+logboth () {
     echo "${@}" >&2
+    syslogger "${@}"
+}
+
+die () {
+    logboth "$@"
     exit 1
 }
 
@@ -57,7 +66,7 @@ log () {
     if $interactive; then
         echo "$@" >&2
     else
-        /usr/bin/logger -i -p security.err -t "verify-fs" "${@}"
+        syslogger "${@}"
     fi
 }
 

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -77,6 +77,13 @@ EOF
 
 ##### MAIN #####
 
+if tty -s; then
+    interactive=true
+else
+    interactive=false
+fi
+#echo "D: interactive=$interactive" >&2
+
 ## 0.) Check the paths
 
 [[ $(< /proc/mounts) =~ upperdir=${OVERLAY} ]] || \
@@ -132,12 +139,6 @@ for ROOTFS in *.squashfs; do
 
 done
 popd >/dev/null
-
-if tty -s; then
-    interactive=true
-else
-    interactive=false
-fi
 
 ## 2.) Verify the overlayfs
 cat_default | while read LINE; do

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -175,5 +175,5 @@ if [ "$PROBLEMCOUNT" = 0 ] ; then
     logboth "SUCCESS: Completed verify-fs at `date -u` with no problems to report (and $MISSINGCOUNT inspected sources were missing)"
 else
     logboth "FAILED: Completed verify-fs at `date -u` with $PROBLEMCOUNT problems to report (and $MISSINGCOUNT inspected sources were missing)"
-#    exit 1
+    exit 1
 fi

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -51,6 +51,8 @@ is_tree_empty () {
     [[ $(find "${dir}" -xdev "${excludes[@]}" -type f -print | wc -l) == 0 ]]
 }
 
+# By default, go to stderr (e.g. systemd unit journal)
+interactive=true
 log () {
     if $interactive; then
         echo "$@" >&2

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# NOTE: Bash-specific syntax IS used in this codebase
+
 #
 # Copyright (C) 2015 - 2020 Eaton
 #
@@ -163,7 +165,7 @@ done
 popd >/dev/null
 
 ## 2.) Verify the overlayfs
-cat_default | while read LINE; do
+while read LINE; do
     TREE=${LINE%%:*}
     EXCLUDES=${LINE#*:}
 
@@ -171,7 +173,7 @@ cat_default | while read LINE; do
 
     is_tree_empty "${OVERLAY}/${TREE}" ${EXCLUDES//:/ } || \
         { log "${OVERLAY}/${TREE} contains suspicious files." ; PROBLEMCOUNT=$(($PROBLEMCOUNT+1)); }
-done
+done < <(cat_default)
 
 if [ "$PROBLEMCOUNT" = 0 ] ; then
     logboth "SUCCESS: Completed verify-fs at `date -u` with no problems to report (and $MISSINGCOUNT inspected sources were missing)"

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -164,6 +164,8 @@ for ROOTFS in *.squashfs; do
 done
 popd >/dev/null
 
+PROBLEMCOUNT_RO_INTEGRITY=$PROBLEMCOUNT
+
 ## 2.) Verify the overlayfs
 while read LINE; do
     TREE=${LINE%%:*}
@@ -178,6 +180,6 @@ done < <(cat_default)
 if [ "$PROBLEMCOUNT" = 0 ] ; then
     logboth "SUCCESS: Completed verify-fs at `date -u` with no problems to report (and $MISSINGCOUNT inspected sources were missing)"
 else
-    logboth "FAILED: Completed verify-fs at `date -u` with $PROBLEMCOUNT problems to report (and $MISSINGCOUNT inspected sources were missing)"
+    logboth "FAILED: Completed verify-fs at `date -u` with $PROBLEMCOUNT problem(s) to report (of which $PROBLEMCOUNT_RO_INTEGRITY were issues with read-only archive integrity, and $MISSINGCOUNT inspected sources were missing)"
     exit 1
 fi

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -120,6 +120,8 @@ for ROOTFS in *.squashfs; do
         MISSINGCOUNT=$(($MISSINGCOUNT+1))
     fi
 
+    # TODO: Check the cksum file for length (and weak CRC)
+    # TODO: Check the length of OS image file from manifest
     if [ -s "${ROOTFS}.sha256" ] ; then
         if /usr/bin/sha256sum -c "${ROOTFS}.sha256" 2>/dev/null; then
             if [ -s "${ROOTFS}-manifest.json" ] ; then


### PR DESCRIPTION
As reviewed recently, we had a problem with verify-fs calling `log()` before it knew where to send the reports (stderr or syslog via `logger`).

This PR fixes that, and also adds a summary report (to both of these log targets) that the inspection ran and whether it found any mismatches.

Finally, if some were found, it (newly) exits with an error, failing the service unit visibly.