### PR TITLE
obs/preinstallimage-bios.sh.in : fix database to localhost… (2.1.0)

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -530,6 +530,18 @@ mkdir -p /etc/malamute
 cp /usr/share/fty/examples/config/malamute/malamute.cfg /etc/malamute
 /bin/systemctl enable malamute
 
+# Fix up where mariadb listens
+case "$IMGTYPE" in
+    *devel*) ;; # let it be for testing and developers
+    deploy|*)
+cat > /etc/my.cnf.d/localhost.cnf << EOF
+[mysqld]
+bind-address = 127.0.0.1
+port = 3306
+EOF
+        ;;
+esac
+
 # Enable 42ity services (distributed as a systemd preset file)
 if [ "${OSIMAGE_DISTRO}" = "Debian_10.0" ]; then
     /bin/systemctl disable mysql.service || true


### PR DESCRIPTION
… on non-devel OS images (see #432 for master)

Dev-tested on latest release candidate (without the file it listens on `:::3306`, with the file it listens on `127.0.0.1:3306`)

@EatonEKia : I did not quickly pick a syntax to have it listen on both IPv4 and IPv6 localhosts. With multiple lines, the latest one is used; with comma-separated list of IPs the server does not start. So TODO for later... maybe not at all possible, per https://www.cyberciti.biz/faq/unix-linux-mysqld-server-bind-to-more-than-one-ip-address/