### PR TITLE
Limit SSH to Administrator user (2.1.0)

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -508,8 +508,7 @@ cp /usr/share/fty/examples/config/update-rc3.d/* /etc/update-rc3.d
 rm /etc/init.d/ssh*
 echo "UseDNS no" >> /etc/ssh/sshd_config
 # Limit to Administrator user (i.e. no Viewers like "monitor")
-echo "AllowGroups bios-admin" >> /etc/ssh/sshd_config
-echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
+echo "AllowGroups bios-admin root" >> /etc/ssh/sshd_config
 rm /etc/ssh/*key*
 mkdir -p /etc/systemd/system
 sed 's|\[Service\]|[Service]\nExecStartPre=/usr/bin/ssh-keygen -A|' /lib*/systemd/system/ssh@.service > /etc/systemd/system/ssh@.service

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -507,6 +507,8 @@ cp /usr/share/fty/examples/config/update-rc3.d/* /etc/update-rc3.d
 # Enable ssh
 rm /etc/init.d/ssh*
 echo "UseDNS no" >> /etc/ssh/sshd_config
+# Limit to Administrator user (i.e. no Viewers like "monitor")
+echo "AllowGroups bios-admin" >> /etc/ssh/sshd_config
 rm /etc/ssh/*key*
 mkdir -p /etc/systemd/system
 sed 's|\[Service\]|[Service]\nExecStartPre=/usr/bin/ssh-keygen -A|' /lib*/systemd/system/ssh@.service > /etc/systemd/system/ssh@.service

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -509,6 +509,7 @@ rm /etc/init.d/ssh*
 echo "UseDNS no" >> /etc/ssh/sshd_config
 # Limit to Administrator user (i.e. no Viewers like "monitor")
 echo "AllowGroups bios-admin" >> /etc/ssh/sshd_config
+echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
 rm /etc/ssh/*key*
 mkdir -p /etc/systemd/system
 sed 's|\[Service\]|[Service]\nExecStartPre=/usr/bin/ssh-keygen -A|' /lib*/systemd/system/ssh@.service > /etc/systemd/system/ssh@.service

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -509,6 +509,10 @@ rm /etc/init.d/ssh*
 echo "UseDNS no" >> /etc/ssh/sshd_config
 # Limit to Administrator user (i.e. no Viewers like "monitor")
 echo "AllowGroups bios-admin root" >> /etc/ssh/sshd_config
+if ! egrep '^[ \t]*PermitRootLogin without-password' /etc/ssh/sshd_config >/dev/null ; then
+    # Allow root login with ssh-keys only, and only if someone presets them (CI)
+    echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
+fi
 rm /etc/ssh/*key*
 mkdir -p /etc/systemd/system
 sed 's|\[Service\]|[Service]\nExecStartPre=/usr/bin/ssh-keygen -A|' /lib*/systemd/system/ssh@.service > /etc/systemd/system/ssh@.service


### PR DESCRIPTION
Limit SSH to Administrator user (i.e. no Viewers like "monitor")