### PR TITLE
Backport SSHD units fixes from featureimage/deb10

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -556,8 +556,10 @@ if ! egrep '^[ \t]*PermitRootLogin without-password' /etc/ssh/sshd_config >/dev/
 fi
 rm /etc/ssh/*key*
 mkdir -p /etc/systemd/system
-sed 's|\[Service\]|[Service]\nExecStartPre=/usr/bin/ssh-keygen -A|' /lib*/systemd/system/ssh@.service > /etc/systemd/system/ssh@.service
-sed -i 's|\[Unit\]|[Unit]\nConditionPathExists=/var/lib/fty/fty-eula/license\nConditionPathExists=@OVERLAY_PATH@/etc/shadow|' /etc/systemd/system/ssh@.service
+sed -e 's|\[Service\]|[Service]\nExecStartPre=/usr/bin/ssh-keygen -A\nExecStartPre=/bin/mkdir -p /run/sshd\nExecStartPre=/bin/chmod 0755 /run/sshd\n|' \
+    -e 's|\[Unit\]|[Unit]\nConditionPathExists=/var/lib/fty/fty-eula/license\nConditionPathExists=@OVERLAY_PATH@/etc/shadow|' \
+    -e 's|^\(RuntimeDirectory.*=.*\)$|#AVOID_REMOVING# \1|' \
+    < /lib/systemd/system/ssh@.service > /etc/systemd/system/ssh@.service
 /bin/systemctl disable ssh.service
 /bin/systemctl mask ssh.service
 /bin/systemctl enable ssh.socket

--- a/systemd/bios-ssh-last-resort.service.in
+++ b/systemd/bios-ssh-last-resort.service.in
@@ -7,7 +7,7 @@ EnvironmentFile=-/etc/default/ssh
 ExecStartPre=/usr/bin/ssh-keygen -A
 ExecStartPre=/bin/mkdir -p /run/sshd
 ExecStartPre=/bin/chmod 0755 /run/sshd
-ExecStart=/usr/sbin/sshd -D $SSHD_OPTS -p 4222
+ExecStart=/usr/sbin/sshd -D $SSHD_OPTS -p 4222 -o PidFile=/run/sshd-bios-last-resort.pid
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/systemd/bios-ssh-last-resort.service.in
+++ b/systemd/bios-ssh-last-resort.service.in
@@ -7,7 +7,9 @@ EnvironmentFile=-/etc/default/ssh
 ExecStartPre=/usr/bin/ssh-keygen -A
 ExecStartPre=/bin/mkdir -p /run/sshd
 ExecStartPre=/bin/chmod 0755 /run/sshd
+ExecStartPre=/usr/sbin/sshd -t
 ExecStart=/usr/sbin/sshd -D $SSHD_OPTS -p 4222 -o PidFile=/run/sshd-bios-last-resort.pid
+ExecReload=/usr/sbin/sshd -t
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/systemd/bios-ssh-last-resort.service.in
+++ b/systemd/bios-ssh-last-resort.service.in
@@ -5,8 +5,8 @@ After=auditd.service network.service
 [Service]
 EnvironmentFile=-/etc/default/ssh
 ExecStartPre=/usr/bin/ssh-keygen -A
-ExecStartPre=/bin/mkdir -p /var/run/sshd
-ExecStartPre=/bin/chmod 0755 /var/run/sshd
+ExecStartPre=/bin/mkdir -p /run/sshd
+ExecStartPre=/bin/chmod 0755 /run/sshd
 ExecStart=/usr/sbin/sshd -D $SSHD_OPTS -p 4222
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
These changes are still in testing on the feature image, so not part of the earlier big backport PR #439.
Without something like this in place, an SSH login (and logout) on port 22 breaks connectability on port 4222 as used by CI and fallback support.