### PR TITLE
update-rc3: Do not overwrite /var/lib/fty/sw-update/activation_requested by exit-code

### DIFF
--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1560,7 +1560,7 @@ download_osimage() (
     # This chroot should happen after the currently deployed version has
     # confirmed trust to that new image, however (checksums/signatures).
     mkdir -p @ftydatadir@/sw-update/ && \
-    ( etn-sw-update --add-image "${aTGT_FILE}" || echo "$?" > "@ftydatadir@/sw-update/activation_requested" ) && \
+    ( etn-sw-update --add-image "${aTGT_FILE}" ; echo "$?" > "@ftydatadir@/sw-update/activation_requested.status" ) && \
     logmsg_info "Got $REPORT_IMAGETYPE OK:" && \
     ls -ld "${aTGT_FILE}" "${aTGT_FILE_CSOLD[@]}" "${aTGT_FILE_MANIFEST}" && \
     cat "${aTGT_FILE_CSOLD[@]}" && \


### PR DESCRIPTION
[PQSW-284] update-rc3.in : modern etn-sw-update maintains /var/lib/fty/sw-update/activation_requested with the image number in manifest, we should not overwrite it with the exit-code