### PR TITLE
Avoid failing /etc/mysql/debian-start from Debian-provided mariadb

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -251,6 +251,7 @@ ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_builddir)/setup/20-th-names.sh \
 	$(top_builddir)/setup/20-rcmysql-transient.sh \
+	$(top_srcdir)/setup/90-mylogin.everytime.sh \
 	$(top_srcdir)/setup/90-ntp-dhcp-conf.everytime.sh \
 	$(top_srcdir)/setup/90-nut-ownership.everytime.sh \
 	$(top_srcdir)/setup/90-sw-manifest.sh \
@@ -270,6 +271,7 @@ EXTRA_DIST += \
 	$(top_srcdir)/setup/20-ipc-lcd-services.sh \
 	$(top_srcdir)/setup/20-th-names.sh.in \
 	$(top_srcdir)/setup/20-rcmysql-transient.sh.in \
+	$(top_srcdir)/setup/90-mylogin.everytime.sh \
 	$(top_srcdir)/setup/90-ntp-dhcp-conf.everytime.sh \
 	$(top_srcdir)/setup/90-nut-ownership.everytime.sh \
 	$(top_srcdir)/setup/90-sw-manifest.sh \

--- a/setup/90-mylogin.everytime.sh
+++ b/setup/90-mylogin.everytime.sh
@@ -22,6 +22,10 @@
 #! \file    90-mylogin.everytime.sh
 #  \brief   Make sure debian init script for mariadb maintenance can log into it
 #  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#
+#   Note: this file is also called, if present, by fty-db-init to
+#   add the password reference as soon as it generates one. Do not
+#   rename this scriptlet carelessly!
 
 die() {
     echo "FATAL: $*" >&2

--- a/setup/90-mylogin.everytime.sh
+++ b/setup/90-mylogin.everytime.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2020 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    90-mylogin.everytime.sh
+#  \brief   Make sure debian init script for mariadb maintenance can log into it
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+
+die() {
+    echo "FATAL: $*" >&2
+    exit 1
+}
+
+skip() {
+    echo "SKIP: $*" >&2
+    exit 0
+}
+
+if [ -s /root/.my.cnf ] && [ -s /etc/mysql/debian.cnf ]; then
+    grep "include /root/.my.cnf" /etc/mysql/debian.cnf >/dev/null \
+    && skip "Already applied" \
+    || ( echo '!include /root/.my.cnf' >> /etc/mysql/debian.cnf || die "Could not update /etc/mysql/debian.cnf" )
+else
+    skip "Not applicable to current system, maybe on another boot..."
+fi

--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -404,6 +404,11 @@ EOF
 		return 1
 	fi
 
+	if [ -x "@datadir@/@PACKAGE@/setup/90-mylogin.everytime.sh" ]; then
+		echo "Try to arrange that our new login is known by OS-provided tools and scripts"
+		"@datadir@/@PACKAGE@/setup/90-mylogin.everytime.sh" || true
+	fi
+
 	return 0
 }
 


### PR DESCRIPTION
After our system has initialized fty-db-init with a database password, subsequent starts of fty-db-engine log that they can not run that script full of helper tools. Same can be said for upgrades with older existing database and login into the newer images, so the reconciliation of that script with our setup is done both at startups via ipc-meta-setup and right after we've generated and tested a database password in fty-db-init.