### PR TITLE
Make sure the verify-fs reports early after boot do get logged

### DIFF
--- a/systemd/biostimer-verify-fs.service.in
+++ b/systemd/biostimer-verify-fs.service.in
@@ -1,5 +1,8 @@
 [Unit]
 Description=42ity-Timer service that verify integrity of filesystem and reports issues to syslog
+# Make sure our report is logged, rotated and disseminated
+Wants=rsyslogd.service syslog.socket
+After=rsyslogd.service syslog.socket
 
 [Service]
 Type=simple

--- a/tools/verify-fs.in
+++ b/tools/verify-fs.in
@@ -28,8 +28,11 @@
 #
 
 OVERLAY=@OVERLAY_PATH@
-DEFAULT=/etc/default/verify-fs
 IMAGES=@IMAGES_PATH@
+
+# Colon-separated paths, line by line, to check for no-changes in overlay
+# See cat_default() for format example (and hardcoded default set) below
+DEFAULT=/etc/default/verify-fs
 
 JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
 get_a_string_arg() { "$JSONSH" --get-string "$1" ; }


### PR DESCRIPTION
Essentially, make sure syslog.service (pulled by syslog.socket and implemented for us by rsyslogd.service) is running before this script is.

If there was some error starting it, we have a major issue so there is no fallback to write into a log file directly and so avoid the CI errors (sometimes we do lack the log file to GET in CI - for normal circumstances of unmanage startup race, this PR should solve that; any remaining faults are still of interest).