### PR TITLE
Update-rc3 enhancements related to ova loader

### DIFF
--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1952,8 +1952,9 @@ apply_rawfwimage_ovaloader() (
     # its practical contents (GRUB sectors, miniroot file) may be
     # the same. Learn to compare that deep...
     # NOTE: For now we trust that anything in recovery or production
-    # locations is trustworthy!
-    # Note that there may be several suitable patterns coming from
+    # locations is trustworthy - in particular that checksums were
+    # verified earlier by download or Upgrade Package tarball unpack!
+    # NOTE that there may be several suitable patterns coming from
     # different levels of development, e.g. "${osimagebasename}.loader.gz"
     # or "ovaloader-gitdate~githash@distro.gz" or fallback "ovaloader.gz"
     # (or not .gz generally)

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1859,6 +1859,11 @@ findnewest_rawfwimage_ovaloader() (
     # * An "${osimagebasename}.loader.gz" is published near OS image
     #   in SOURCESITEROOT_OSIMAGE and named with same prefix as the
     #   OS image we chose to use - gotta know that bit at this point
+    # ** Same OS image basename as one currently being downloaded
+    # ** Newest OS image basename of those already downloaded to the
+    #    recovery location if none is now downloaded to update into
+    # ** Same OS image basename as currently applied if none is
+    #    downloaded to update into
     # * (?) Some newest *.loader.gz in SOURCESITEROOT_OSIMAGE if present?
     # * Newest ovaloader-gitdate~githash@distro.gz in SOURCESITEROOTFW_OVALOADER
     #   possibly adjusted for the current image branch (master, stable,

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1900,7 +1900,7 @@ removeold_rawfwimage_ovaloader() (
     fi
     VICTIMS=0
     VICTIMPATHS=""
-    for F in `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/ovaloader{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/ovaloader{,.gz} 2>/dev/null` ; do
+    for F in `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/ovaloader*{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/ovaloader*{,.gz} "${DOWNLOADROOTFW_OVALOADER}"/*.loader{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/*.loader{,.gz} 2>/dev/null` ; do
         [ -n "$DOWNLOADED_FW_OVALOADER" ] && [ -s "$DOWNLOADED_FW_OVALOADER" ] && [ "$DOWNLOADED_FW_OVALOADER" = "$F" ] && \
             { logmsg_info "Keeping the just-downloaded $REPORT_IMAGETYPE: '$DOWNLOADED_FW_OVALOADER'" ; continue ; }
         logmsg_info "Removing older $REPORT_IMAGETYPE: '`pwd`/$F' and its checksum(s)"
@@ -1952,8 +1952,14 @@ apply_rawfwimage_ovaloader() (
     # the same. Learn to compare that deep...
     # NOTE: For now we trust that anything in recovery or production
     # locations is trustworthy!
-    local FB FS
-    for F in `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/ovaloader{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/ovaloader{,.gz} 2>/dev/null` ; do
+    # Note that there may be several suitable patterns coming from
+    # different levels of development, e.g. "${osimagebasename}.loader.gz"
+    # or "ovaloader-gitdate~githash@distro.gz" or fallback "ovaloader.gz"
+    # (or not .gz generally)
+    local FB FS F
+    for F in \
+        `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} 2>/dev/null` \
+    ; do
         if [ -s "$F" ] ; then
             FB="`dirname "$F"`/`basename "$F" .gz`"
             for CSALGO in $CHECKSUM_ALGOLIST_DEFAULT ; do
@@ -2395,7 +2401,7 @@ if [ x"$ACTION_FORCEFLASH_CLEANUP" = xyes ]; then
 	rm -f "${DEPLOYMENTROOTFW_UBOOT}/u-Boot.forceflash" "${DOWNLOADROOTFW_UBOOT}/u-Boot.forceflash"
 	rm -f "${DEPLOYMENTROOTFW_UIMAGE}/uImage.forceflash" "${DOWNLOADROOTFW_UIMAGE}/uImage.forceflash"
 	rm -f "${DEPLOYMENTROOT_OSIMAGE}"/*.forceflash "${DOWNLOADROOT_OSIMAGE}"/*.forceflash
-	rm -f "${DEPLOYMENTROOTFW_OVALOADER}/ovaloader.forceflash" "${DOWNLOADROOTFW_OVALOADER}/ovaloader.forceflash"
+	rm -f "${DEPLOYMENTROOTFW_OVALOADER}/{ovaloader*,*.loader}{,.gz}.forceflash" "${DOWNLOADROOTFW_OVALOADER}/{ovaloader*,*.loader}{,.gz}.forceflash"
 fi
 
 # Checks are special - after we do all which were requested (if any), we exit
@@ -2450,7 +2456,7 @@ if [ x"$ACTION_CHECK_OSIMAGE" = xyes ] || [ x"$ACTION_CHECK_FWIMAGE" = xyes ]; t
 	fi
 	if [ "$ACTION_FORCEFLASH_FWIMAGE_OVALOADER" = yes -a "$RESULT_ACTION_CHECK_OVALOADER" = 0 ] ; then
 		logmsg_info "Adding a touch of ovaloader forceflash, as requested"
-		rm -f "${DEPLOYMENTROOTFW_OVALOADER}/ovaloader.forceflash" "${DOWNLOADROOTFW_OVALOADER}/ovaloader.forceflash"
+		rm -f "${DEPLOYMENTROOTFW_OVALOADER}/{ovaloader*,*.loader}{,.gz}.forceflash" "${DOWNLOADROOTFW_OVALOADER}/{ovaloader*,*.loader}{,.gz}.forceflash"
 		case "${DOWNLOADED_FW_OVALOADER}" in
 			/dev*) [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ] && removeold_rawfwimage_ovaloader ;;
 			*)
@@ -2546,7 +2552,7 @@ if [ "$ACTION_DOWNLOAD_FWIMAGE" = yes ]; then
 	   [ "$RESULT_ACTION_DOWNLOAD_FWIMAGE_RAW_OVALOADER" = 0 -o "$RESULT_ACTION_DOWNLOAD_FWIMAGE_RAW_OVALOADER" = 42 ] \
 	; then
 		logmsg_info "Adding a touch of ovaloader forceflash, as requested"
-		rm -f "${DEPLOYMENTROOTFW_OVALOADER}/ovaloader.forceflash" "${DOWNLOADROOTFW_OVALOADER}/ovaloader.forceflash"
+		rm -f "${DEPLOYMENTROOTFW_OVALOADER}/{ovaloader*,*.loader}{,.gz}.forceflash" "${DOWNLOADROOTFW_OVALOADER}/{ovaloader*,*.loader}{,.gz}.forceflash"
 		case "${DOWNLOADED_FW_OVALOADER}" in
 			/dev*) [ "$ACTION_REMOVEOLD_FWIMAGE" = yes ] && removeold_rawfwimage_ovaloader ;;
 			*)

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -945,6 +945,10 @@ download_rawfwimage_generic() (
     cd "${DOWNLOADROOT_THISIMAGE}" || \
     cd "${DEPLOYMENTROOT_THISIMAGE}" || die "Can not use DOWNLOADROOT_THISIMAGE_VARNAME='$DOWNLOADROOT_THISIMAGE' nor DEPLOYMENTROOT_THISIMAGE_VARNAME='$DEPLOYMENTROOT_THISIMAGE'"
 
+    # TODO-OVA: truncate custom (or discovered) URL at least for ovaloader
+    # to be without the .gz suffix which would be added anyway, and fetch
+    # all available checksums for both uncompressed and compressed (if such
+    # file exists) contents.
     case "${1-}" in
         ""|*://*/)
             logmsg_info "Fetching newest remote filename for the ${RAW_DEVICE_NODE:+raw }$REPORT_IMAGETYPE..."
@@ -2001,7 +2005,7 @@ apply_rawfwimage_ovaloader() (
                         "${OVALOADER_DEVICE}" "${FB}.${CSALGO}" \
                     && { logmsg_info "Matched checksum from '${FB}.${CSALGO}' with current content of '${OVALOADER_DEVICE}', nothing to do" ; return 0 ; }
                 elif [ -s "$F.$CSALGO" ] ; then
-                    # Do we only have e.g. the ovaloader.gz.sha256 ?
+                    # Do we only have e.g. the ovaloader.gz.sha256? Validate the image file (we might have downloaded it in another run, or user might have planted stuff)
                     ensure_checksum "$F" "$F.$CSALGO" || break 2  # return # die "Checksum verification failed for '$F'!"
 
                     # TODO-OVA: Check if we need (or can abstract) making a compressed payload's checksum?

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1877,6 +1877,15 @@ findnewest_rawfwimage_ovaloader() (
 )
 
 download_rawfwimage_ovaloader() (
+    # TODO-OVA: There is a nuance that for loaders that we build once per
+    # git commit and publish in DOWNLOADROOTFW_OVALOADER location, there
+    # may be lots of identical binaries published at various URLs and file
+    # names, linked as recommended loader to go with this or that OS image:
+    # ${SOURCESITEROOT_OSIMAGE}/${SOURCESITEROOT_OSIMAGE_FILENAMEPATTERN}.loader*
+    # If the downloader has a local OVA loader file already, and another one
+    # seems a better match to fetch by naming considerations, make sure that
+    # the checksum is not already identical and then only filenames differ.
+
     download_rawfwimage_generic \
         'download_rawfwimage_ovaloader' \
         'OVA loader and kernel' \

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -232,8 +232,9 @@ usage() {
     echo "the following arguments ('raw' firmwares are the non-tarballed singular files):"
     echo "  --url-image-os|-U {URL} (expected checksum patterns should still exist nearby)"
   { test -z "$DOWNLOADROOTFW_UBOOT" && test -z "$DOWNLOADROOTFW_OVALOADER"; } || { \
-    echo "  --url-image-fw-raw-uboot --url-image-fw-raw-uimage --url-image-fw-raw-modules"
-    echo "  --url-image-fw-raw-ovaloader"
+    echo "  --url-image-fw-raw-uboot|-Ub"
+    echo "  --url-image-fw-raw-uimage|-Ui   --url-image-fw-raw-modules|-Um"
+    echo "  --url-image-fw-raw-ovaloader|-Uo"
   }
     echo "  --(no-)erase-factory-reset If a new OS image downloaded successfully, touch"
     echo "                   the control file so 'init' does a factory reset after reboot"
@@ -2332,10 +2333,10 @@ while [ $# -gt 0 ]; do
 		                    ;;
 		                *)  URL_DOWNLOAD_OSIMAGE="$2" ;;
 		            esac ;;
-		        --url-image-fw-raw-uboot)   URL_DOWNLOAD_FWIMAGE_RAW_UBOOT="$2" ;;
-		        --url-image-fw-raw-uimage)  URL_DOWNLOAD_FWIMAGE_RAW_UIMAGE="$2" ;;
-		        --url-image-fw-raw-modules) URL_DOWNLOAD_FWIMAGE_RAW_MODULES="$2" ;;
-		        --url-image-fw-raw-ovaloader)  URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER="$2" ;;
+		        --url-image-fw-raw-uboot|-Ub)   URL_DOWNLOAD_FWIMAGE_RAW_UBOOT="$2" ;;
+		        --url-image-fw-raw-uimage|-Ui)  URL_DOWNLOAD_FWIMAGE_RAW_UIMAGE="$2" ;;
+		        --url-image-fw-raw-modules|-Um) URL_DOWNLOAD_FWIMAGE_RAW_MODULES="$2" ;;
+		        --url-image-fw-raw-ovaloader|-Uo)  URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER="$2" ;;
 		        *)  die "Aborting due to unknown command-line argument(s): $*" ;;
 		    esac
 		    shift ;;

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1863,6 +1863,7 @@ findnewest_rawfwimage_ovaloader() (
     #   possibly adjusted for the current image branch (master, stable,
     #   featureimage X, release X) or fallback to master if absent.
     # * Symlinked ovaloader.gz in SOURCESITEROOTFW_OVALOADER (like above)
+    # TODO-OVA
     IMAGE_URL="`lsdir_http_pattern "${1:-$SOURCESITEROOTFW_OVALOADER}" "ovaloader" | sort -n | tail -1`"
     if [ $? = 0 -a x"$IMAGE_URL" != x ]; then
         echo "$IMAGE_URL" && return 0
@@ -1977,7 +1978,7 @@ apply_rawfwimage_ovaloader() (
             done
             logmsg_info "apply_rawfwimage_ovaloader(): Trying to flash '$F' into '${OVALOADER_DEVICE}' ..."
             case "$F" in
-                *.gz) # TODO: size check for gzip
+                *.gz) # TODO: quicker size check for gzip itself (e.g. from manifest)?
                     FS="`gzip -cd < "$F" | wc -c`"
                     # As a sanity check, require that these are equal (not less-than)
                     [ "$FS" = "$OVALOADER_MAX_SIZE_IPM2" ] || die "Trying to flash $REPORT_IMAGETYPE sized '$FS' bytes to device sized '$OVALOADER_MAX_SIZE_IPM2'"
@@ -2181,7 +2182,7 @@ ACTION_FORCEFLASH_CLEANUP="no"
 [ -z "${URL_DOWNLOAD_FWIMAGE_RAW_UBOOT-}" ] &&      URL_DOWNLOAD_FWIMAGE_RAW_UBOOT=""
 [ -z "${URL_DOWNLOAD_FWIMAGE_RAW_UIMAGE-}" ] &&     URL_DOWNLOAD_FWIMAGE_RAW_UIMAGE=""
 [ -z "${URL_DOWNLOAD_FWIMAGE_RAW_MODULES-}" ] &&    URL_DOWNLOAD_FWIMAGE_RAW_MODULES=""
-[ -z "${URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER-}" ] &&     URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER=""
+[ -z "${URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER-}" ] &&  URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER=""
 
 ACTION_REMOVEOLD_OSIMAGE="yes"
 # This is currently no-op because we only track "raw" FW images which have one
@@ -2221,6 +2222,8 @@ TEMP_DATA="`mktemp -d /var/run/.update-rc3.$$.XXXXXX`" && [ -n "$TEMP_DATA" ] &&
 || { TEMP_DATA="/tmp/.update-rc3.$$" && rm -rf "${TEMP_DATA}" && mkdir -p "$TEMP_DATA" ; } \
 || die "Can not make a TEMP_DATA directory"
 export TEMP_DATA
+echo "Using a TEMP_DATA directory: '${TEMP_DATA}/'" >&2
+
 TRAP_SIGNALS="HUP INT QUIT TERM EXIT" settraps "rm -rf '${TEMP_DATA}'"
 
 while [ $# -gt 0 ]; do
@@ -2274,6 +2277,11 @@ while [ $# -gt 0 ]; do
 			PID3=$!
 			summarize_check "LOADER-UBOOT"   download_rawfwimage_uboot   $URL_DOWNLOAD_FWIMAGE_RAW_UBOOT &
 			PID4=$!
+			# TODO-OVA: Infer URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER from the
+			# URL_DOWNLOAD_OSIMAGE value by default, or use common build
+			# products if nothing specific to a chosen one OS image is
+			# published near it. Above that all, trust what user told to
+			# use with a CLI option below, though.
 			summarize_check "KERNEL-OVALOADER"  download_rawfwimage_ovaloader  $URL_DOWNLOAD_FWIMAGE_RAW_OVALOADER &
 			PID5=$!
 			for P in $PID1 $PID2 $PID3 $PID4 $PID5 ; do wait $P || RES=$? ; done

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -454,9 +454,11 @@ remove_image() {
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"'\.[^\:]*'
     # Note: we do not really support e.g. broken FILENAME and good FILENAME.gz
-    rm -f "$1"{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512,.cksum}{,-padded}{,.tmp}{,.gz} ${2:+"$2"}
+    # and might have the .gz suffix in various places historically
+    rm -f "`basename "$1" .gz`"{,.gz}{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512,.cksum}{,-padded}{,.tmp}{,.gz} ${2:+"$2"}
 
-    # ...and update the SW package manifest
+    # ...and update the SW package manifest, if this was an OS image
+    # or some other artefact tracked by etn-licensing.
     # WARNING: this MUST be done before package manifest deletion!
     # TODO: By the licensing-aware updates design, the new candidate image's
     # copy of the generalized upgradeability validation routine should be

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1989,10 +1989,30 @@ apply_rawfwimage_ovaloader() (
             FB="`dirname "$F"`/`basename "$F" .gz`"
             for CSALGO in $CHECKSUM_ALGOLIST_DEFAULT ; do
                 if [ -s "$FB.$CSALGO" ] ; then
+                    # Do we have e.g. the ovaloader.sha256 file (for uncompressed payload)?
+                    # Note that verifier should transparently handle compressed downloaded file vs raw content's checksum
                     ensure_checksum "$FB" "$FB.$CSALGO" || break 2  # return # die "Checksum verification failed for '$FB'!"
+
+                    # If the checksum matches, we are done.
+                    # First checked good image wins anyway.
+                    # (Tweak prios by forceflash if needed.)
+                    FLAG_CAN_REMOVE_IMAGES="no" \
+                    verify_checksum \
+                        "${OVALOADER_DEVICE}" "${FB}.${CSALGO}" \
+                    && { logmsg_info "Matched checksum from '${FB}.${CSALGO}' with current content of '${OVALOADER_DEVICE}', nothing to do" ; return 0 ; }
+                elif [ -s "$F.$CSALGO" ] ; then
+                    # Do we only have e.g. the ovaloader.gz.sha256 ?
+                    ensure_checksum "$F" "$F.$CSALGO" || break 2  # return # die "Checksum verification failed for '$F'!"
+
+                    # TODO-OVA: Check if we need (or can abstract) making a compressed payload's checksum?
+                    # Or more reliably, uncompress the known-good downloaded file to know its uncompressed value's checksum to compare with on-disk image?
+                    #FLAG_CAN_REMOVE_IMAGES="no" \
+                    #verify_checksum \
+                    #    "${OVALOADER_DEVICE}" "${F}.${CSALGO}" \
+                    #&& { logmsg_info "Matched checksum from '${F}.${CSALGO}' with current content of '${OVALOADER_DEVICE}', nothing to do" ; return 0 ; }
                 fi
             done
-            logmsg_info "apply_rawfwimage_ovaloader(): Trying to flash '$F' into '${OVALOADER_DEVICE}' ..."
+            logmsg_info "apply_rawfwimage_ovaloader(): Could not compare checksums, or new candidate differs from on-disk image. Trying to flash '$F' into '${OVALOADER_DEVICE}' ..."
             case "$F" in
                 *.gz) # TODO: quicker size check for gzip itself (e.g. from manifest)?
                     FS="`gzip -cd < "$F" | wc -c`"

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -2250,6 +2250,8 @@ while [ $# -gt 0 ]; do
 				| egrep -v '\.(md5|sha256|cksum'"${CHECKSUM_ALGO_DEFAULT:+|$CHECKSUM_ALGO_DEFAULT}"')$' || RES=$?
 			lsdir_http_pattern "${SOURCESITEROOTFW_MODULES}" "*[0-9].[0-9]*.${EXT}*" \
 				| egrep -v '\.(md5|sha256|cksum'"${CHECKSUM_ALGO_DEFAULT:+|$CHECKSUM_ALGO_DEFAULT}"')$' || RES=$?
+			lsdir_http_pattern "${SOURCESITEROOT_OSIMAGE}" "${SOURCESITEROOT_OSIMAGE_FILENAMEPATTERN}.loader*" \
+				| egrep -v '\.(md5|sha256|cksum'"${CHECKSUM_ALGO_DEFAULT:+|$CHECKSUM_ALGO_DEFAULT}"')$' || RES=$?
 			lsdir_http_pattern "${SOURCESITEROOTFW_OVALOADER}" "ovaloader*" \
 				| egrep -v '\.(md5|sha256|cksum'"${CHECKSUM_ALGO_DEFAULT:+|$CHECKSUM_ALGO_DEFAULT}"')$' || RES=$?
 			lsdir_http_pattern "${SOURCESITEROOT_OSIMAGE}" "${SOURCESITEROOT_OSIMAGE_FILENAMEPATTERN}.${EXT}" \

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -122,7 +122,8 @@ config_defaults() {
     is_set SOURCESITEROOTFW_UBOOT || SOURCESITEROOTFW_UBOOT="$SOURCESITEROOTFW"
     is_set SOURCESITEROOTFW_UIMAGE || SOURCESITEROOTFW_UIMAGE="$SOURCESITEROOTFW"
     is_set SOURCESITEROOTFW_MODULES || SOURCESITEROOTFW_MODULES="$SOURCESITEROOTFW/modules"
-    is_set SOURCESITEROOTFW_OVALOADER || SOURCESITEROOTFW_OVALOADER="$SOURCESITEROOTFW"
+    ###is_set SOURCESITEROOTFW_OVALOADER || SOURCESITEROOTFW_OVALOADER="$SOURCESITEROOTFW"
+    is_set SOURCESITEROOTFW_OVALOADER || SOURCESITEROOTFW_OVALOADER="http://obs.roz.lab.etn.com/loader-${OSIMAGE_DISTRO}/@PICK_IMGQALEVEL@/$ARCH/recovery"
 
     # Recovery location (on MMC or mSATA) - for downloads
     is_set DOWNLOADROOT || DOWNLOADROOT="@URC3_DOWNLOADROOT@"
@@ -1847,6 +1848,21 @@ findnewest_rawfwimage_ovaloader() (
     # Echo the URL to the newest "raw" (not tarballed, only one)
     # ovaloader image file found on remote resource, if any
     # Note: currently expects certain filename patterns and http-dir listing markup
+    # Default SOURCESITEROOTFW_OVALOADER="http://obs.roz.lab.etn.com/loader-${OSIMAGE_DISTRO}/@PICK_IMGQALEVEL@/$ARCH/recovery"
+    # expects to resolve @PICK_IMGQALEVEL@ right here (use IMGQALEVEL
+    # if defined here and present on server, or fall back to "master")
+    # Overall, currently we have several options where an image may be
+    # in such order of preference:
+    # * User specified exact URL (use as is)
+    # * User specified a directory URL to look in (match *loader*)
+    # * An "${osimagebasename}.loader.gz" is published near OS image
+    #   in SOURCESITEROOT_OSIMAGE and named with same prefix as the
+    #   OS image we chose to use - gotta know that bit at this point
+    # * (?) Some newest *.loader.gz in SOURCESITEROOT_OSIMAGE if present?
+    # * Newest ovaloader-gitdate~githash@distro.gz in SOURCESITEROOTFW_OVALOADER
+    #   possibly adjusted for the current image branch (master, stable,
+    #   featureimage X, release X) or fallback to master if absent.
+    # * Symlinked ovaloader.gz in SOURCESITEROOTFW_OVALOADER (like above)
     IMAGE_URL="`lsdir_http_pattern "${1:-$SOURCESITEROOTFW_OVALOADER}" "ovaloader" | sort -n | tail -1`"
     if [ $? = 0 -a x"$IMAGE_URL" != x ]; then
         echo "$IMAGE_URL" && return 0

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1957,10 +1957,18 @@ apply_rawfwimage_ovaloader() (
     # or "ovaloader-gitdate~githash@distro.gz" or fallback "ovaloader.gz"
     # (or not .gz generally)
     local FB FS F
+    # Note: we prioritize a *.forceflash hit
     for F in \
+        `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash 2>/dev/null` \
         `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} 2>/dev/null` \
     ; do
         if [ -s "$F" ] ; then
+            case "$F" in
+                *.forceflash)
+                    F="`dirname "$F"`/`basename "$F" .forceflash`"
+                    [ -s "$F" ] || continue
+                    ;;
+            esac
             FB="`dirname "$F"`/`basename "$F" .gz`"
             for CSALGO in $CHECKSUM_ALGOLIST_DEFAULT ; do
                 if [ -s "$FB.$CSALGO" ] ; then


### PR DESCRIPTION
At the time of posting, this is partially functional per intended design, but enough for MVP in the product practice.

The updated script can handle (apply, clean away) more currently supported naming patterns for the OVA loader file present in the recovery location, though currently it should be downloaded with `--url-...` argument or delivered by other means, which is the focus of remaining work in progress.

If the checksum file for uncompressed content of the ovaloader is available (not generated by the script if missing, at this time) then it can be compared to existing on-disk image to quickly skip flashing if already present there. This can be achieved by passing the base URL of the loader file (not `.gz`) for downloading; getting data and both checksums regardless of URL is another focus for remaining work. Automatically picking a best URL of candidate ovaloader for the currently chosen OS image revision, as well as quick-skip if it is same as previously downloaded or flashed content, is yet another WIP.

These nuances currently mostly concern CI and potentially (currently absent) site-local deployment servers providing updates to a farm of deployments, so the PR can be merged "as is" to be a stepping stone for other update management scenarios.