### PR TITLE
Introduce setup/11-mount-boot-noauto.sh and Update OVA loader fix for multiple files present (2.1.0)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -239,6 +239,7 @@ ipc_meta_setup_SCRIPTS = \
 	$(top_srcdir)/setup/01-bios-eula.sh \
 	$(top_srcdir)/setup/10-bios-gpio.sh \
 	$(top_srcdir)/setup/11-forget-bios-devsvcs-1.sh \
+	$(top_srcdir)/setup/11-mount-boot-noauto.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/16-machineid-dir.everytime.sh \
 	$(top_srcdir)/setup/17-proxy-file.everytime.sh \
@@ -254,6 +255,7 @@ EXTRA_DIST += \
 	$(top_srcdir)/setup/01-bios-eula.sh \
 	$(top_srcdir)/setup/10-bios-gpio.sh \
 	$(top_srcdir)/setup/11-forget-bios-devsvcs-1.sh \
+	$(top_srcdir)/setup/11-mount-boot-noauto.sh \
 	$(top_srcdir)/setup/15-dpkg-database.everytime.sh \
 	$(top_srcdir)/setup/16-machineid-dir.everytime.sh \
 	$(top_srcdir)/setup/17-proxy-file.everytime.sh \

--- a/setup/11-mount-boot-noauto.sh
+++ b/setup/11-mount-boot-noauto.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2020 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    11-mount-boot-noauto.sh
+#  \brief   Some releases defaulted to R/W mounts of /boot. Fix that.
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#
+
+# Try to fix the next boot-up's mounts, but do not fail if we could not
+# patch this now (permissions, victim line not there).
+sed -e 's|LABEL=BOOT /boot auto defaults|LABEL=BOOT /boot auto noauto,ro|' \
+    -i /etc/fstab || true
+
+if ( mount | grep '/boot' ) ; then
+    df -k /boot || true
+    umount /boot || \
+    umount -f /boot || \
+    umount -l /boot || \
+    umount -fl /boot || \
+    mount -o remount,ro /boot || \
+    echo "WARNING: It seems /boot was mounted, and still is" >&2
+fi

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1964,13 +1964,16 @@ apply_rawfwimage_ovaloader() (
         `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash 2>/dev/null` \
         `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} 2>/dev/null` \
     ; do
+        logmsg_info "apply_rawfwimage_ovaloader(): Looking at loader file '$F' ..."
+        [ -e "$F" ] || continue
+        case "$F" in
+            *.forceflash)
+                F="`dirname "$F"`/`basename "$F" .forceflash`"
+                logmsg_info "Forceflash converted into '$F'"
+                [ -s "$F" ] || { logmsg_warn "SKIPPED '$F' as not present or empty"; continue; }
+                ;;
+        esac
         if [ -s "$F" ] ; then
-            case "$F" in
-                *.forceflash)
-                    F="`dirname "$F"`/`basename "$F" .forceflash`"
-                    [ -s "$F" ] || continue
-                    ;;
-            esac
             FB="`dirname "$F"`/`basename "$F" .gz`"
             for CSALGO in $CHECKSUM_ALGOLIST_DEFAULT ; do
                 if [ -s "$FB.$CSALGO" ] ; then

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1920,6 +1920,9 @@ apply_rawfwimage_ovaloader() (
     # userland, at least to install a newer loader than can update itself.
 
     local REPORT_IMAGETYPE='OVA loader and kernel'
+    # Result stays 0 if there was nothing to try flashing, but changes to
+    # error if all we did try had failed
+    local FLASHRES=0
 
     case "$ARCH" in
         *86*|*amd64*) ;;
@@ -1979,7 +1982,7 @@ apply_rawfwimage_ovaloader() (
                 if [ -s "$FB.$CSALGO" ] ; then
                     # Do we have e.g. the ovaloader.sha256 file (for uncompressed payload)?
                     # Note that verifier should transparently handle compressed downloaded file vs raw content's checksum
-                    ensure_checksum "$FB" "$FB.$CSALGO" || break 2  # return # die "Checksum verification failed for '$FB'!"
+                    ensure_checksum "$FB" "$FB.$CSALGO" || { FLASHRES=$?; logmsg_error "Checksum verification failed for '$FB'!" ; continue 2 ; }
 
                     # If the checksum matches, we are done.
                     # First checked good image wins anyway.
@@ -1990,7 +1993,7 @@ apply_rawfwimage_ovaloader() (
                     && { logmsg_info "Matched checksum from '${FB}.${CSALGO}' with current content of '${OVALOADER_DEVICE}', nothing to do" ; return 0 ; }
                 elif [ -s "$F.$CSALGO" ] ; then
                     # Do we only have e.g. the ovaloader.gz.sha256? Validate the image file (we might have downloaded it in another run, or user might have planted stuff)
-                    ensure_checksum "$F" "$F.$CSALGO" || break 2  # return # die "Checksum verification failed for '$F'!"
+                    ensure_checksum "$F" "$F.$CSALGO" || { FLASHRES=$?; logmsg_error "Checksum verification failed for '$F'!" ; continue 2 ; }
 
                     # TODO-OVA: Check if we need (or can abstract) making a compressed payload's checksum?
                     # Or more reliably, uncompress the known-good downloaded file to know its uncompressed value's checksum to compare with on-disk image?
@@ -2005,12 +2008,12 @@ apply_rawfwimage_ovaloader() (
                 *.gz) # TODO: quicker size check for gzip itself (e.g. from manifest)?
                     FS="`gzip -cd < "$F" | wc -c`"
                     # As a sanity check, require that these are equal (not less-than)
-                    [ "$FS" = "$OVALOADER_MAX_SIZE_IPM2" ] || die "Trying to flash $REPORT_IMAGETYPE sized '$FS' bytes to device sized '$OVALOADER_MAX_SIZE_IPM2'"
+                    [ "$FS" = "$OVALOADER_MAX_SIZE_IPM2" ] || { FLASHRES=$?; logmsg_error "Trying to flash $REPORT_IMAGETYPE sized '$FS' bytes to device sized '$OVALOADER_MAX_SIZE_IPM2' from file '$F'" ; continue; }
                     gzip -cd < "$F" > "${OVALOADER_DEVICE}" || die "Failed to flash '$F' into '${OVALOADER_DEVICE}'" ;;
                 *)
                     FS="`filesize "$F"`"
                     # As a sanity check, require that these are equal (not less-than)
-                    [ "$FS" = "$OVALOADER_MAX_SIZE_IPM2" ] || die "Trying to flash $REPORT_IMAGETYPE sized '$FS' bytes to device sized '$OVALOADER_MAX_SIZE_IPM2'"
+                    [ "$FS" = "$OVALOADER_MAX_SIZE_IPM2" ] || { FLASHRES=$?; logmsg_error "Trying to flash $REPORT_IMAGETYPE sized '$FS' bytes to device sized '$OVALOADER_MAX_SIZE_IPM2' from file '$F'" ; continue; }
                     cat "$F" > "${OVALOADER_DEVICE}" || die "Failed to flash '$F' into '${OVALOADER_DEVICE}'" ;;
             esac
             sync || die "Failed to sync after flashing '$F' into '${OVALOADER_DEVICE}'"
@@ -2019,7 +2022,11 @@ apply_rawfwimage_ovaloader() (
         fi
     done
 
-    CODE=0 die "apply_rawfwimage_ovaloader(): did not find any (or newer than applied) $REPORT_IMAGETYPE files to try flashing into '${OVALOADER_DEVICE}'"
+    if [ "$FLASHRES" -gt 0 ]; then
+        CODE=$FLASHRES die "apply_rawfwimage_ovaloader(): did not succeed to apply any $REPORT_IMAGETYPE files by flashing into '${OVALOADER_DEVICE}'"
+    else
+        CODE=$FLASHRES die "apply_rawfwimage_ovaloader(): did not find any (or newer than applied) $REPORT_IMAGETYPE files to try flashing into '${OVALOADER_DEVICE}'"
+    fi
 )
 
 ##################################################


### PR DESCRIPTION
Not-yet-tested follow-up to #458 to (eventually) stop mounting `/boot` R/W if we ever did.