### PR TITLE
Small fixes for update-rc3 remove_image() (2.1.0)

### DIFF
--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1222,8 +1222,18 @@ sort_osimage_names() {
     # baseline, or there is one old image for a baseline without a suffix.
     # NOTE: Over project lifetime, the rebuild numbers were separated by "dash"
     # or by "plus" so we support both below.
-    ### sort
-    ### sort -n
+    # TEST: (echo "IPM-3.1.1-5+40"; echo "IPM-3.1.1-50"; echo "IPM-3.1.1-5+4"; echo "IPM-2.2.2"; echo "IPM-2.2.2+13" ; echo "IPM-3.1.1-1"; echo "IPM-3.1.1-1+4" ; echo "fty-20.16.10-12.34.56" ) | ./tools/update-rc3.in  devtest sort_osimage_names -r
+    #   fty-20.16.10-12.34.56
+    #   IPM-3.1.1-50
+    #   IPM-3.1.1-5+40
+    #   IPM-3.1.1-5+4
+    #   IPM-3.1.1-1+4
+    #   IPM-3.1.1-1
+    #   IPM-2.2.2+13
+    #   IPM-2.2.2
+
+    # Puff all numeric suffixes with extra zeroes, run numeric sort,
+    # strip the leading zeroes
     sed -e 's,-\([[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\)_,-\1-0_,' \
         -e 's,\([\-\+]\)\([[:digit:]]\)_,\10\2_,' \
         -e 's,\([\-\+]\)\([[:digit:]][[:digit:]]\)_,\10\2_,' \

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1976,10 +1976,12 @@ apply_rawfwimage_ovaloader() (
     # or "ovaloader-gitdate~githash@distro.gz" or fallback "ovaloader.gz"
     # (or not .gz generally)
     local FB FS F
-    # Note: we prioritize a *.forceflash hit
+    # Note: we prioritize a *.forceflash hit with the most recent touch
+    # and "sort_osimage_names -r" to see newest-named builds in same
+    # family (IPM*, fty*, etc.) first
     for F in \
-        `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash 2>/dev/null` \
-        `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} 2>/dev/null` \
+        `ls -1dt "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz}.forceflash 2>/dev/null` \
+        `ls -1d "${DOWNLOADROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} "${DEPLOYMENTROOTFW_OVALOADER}"/{ovaloader*,*.loader}{,.gz} 2>/dev/null | sort_osimage_names -r` \
     ; do
         logmsg_info "apply_rawfwimage_ovaloader(): Looking at loader file '$F' ..."
         [ -e "$F" ] || continue

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -455,7 +455,8 @@ remove_image() {
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"'\.[^\:]*'
     # Note: we do not really support e.g. broken FILENAME and good FILENAME.gz
     # and might have the .gz suffix in various places historically
-    rm -f "`basename "$1" .gz`"{,.gz}{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512,.cksum}{,-padded}{,.tmp}{,.gz}{,.forceflash} ${2:+"$2"}
+    local BASEPATH="`dirname "$1"`/`basename "$1" .gz`"
+    rm -f "$BASEPATH"{,.gz}{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512,.cksum}{,-padded}{,.tmp}{,.gz}{,.forceflash} ${2:+"$2"}
 
     # ...and update the SW package manifest, if this was an OS image
     # or some other artefact tracked by etn-licensing.

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -455,7 +455,7 @@ remove_image() {
     remove_checksum_cache '[^\:]*' '[^\:]*' "$1"'\.[^\:]*'
     # Note: we do not really support e.g. broken FILENAME and good FILENAME.gz
     # and might have the .gz suffix in various places historically
-    rm -f "`basename "$1" .gz`"{,.gz}{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512,.cksum}{,-padded}{,.tmp}{,.gz} ${2:+"$2"}
+    rm -f "`basename "$1" .gz`"{,.gz}{,.md5,.sha,.sha1,.sha224,.sha256,.sha384,.sha512,.cksum}{,-padded}{,.tmp}{,.gz}{,.forceflash} ${2:+"$2"}
 
     # ...and update the SW package manifest, if this was an OS image
     # or some other artefact tracked by etn-licensing.

--- a/tools/update-rc3.in
+++ b/tools/update-rc3.in
@@ -1214,6 +1214,9 @@ download_rawfwimage_generic() (
 ##################################################
 
 sort_osimage_names() {
+    # Input: pipe from "ls" and the likes
+    # Optional args go to "sort" (e.g. "-r" for reverse)
+    # Output: pipe or redirection or envvar assignment for list of filenames
     # ASSUMPTION: we don't have over 999 rebuilds of the same baseline image ;)
     # ASSUMPTION2: all image builds have a rebuild-index suffix for the same
     # baseline, or there is one old image for a baseline without a suffix.
@@ -1224,7 +1227,7 @@ sort_osimage_names() {
     sed -e 's,-\([[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\)_,-\1-0_,' \
         -e 's,\([\-\+]\)\([[:digit:]]\)_,\10\2_,' \
         -e 's,\([\-\+]\)\([[:digit:]][[:digit:]]\)_,\10\2_,' \
-    | sort -n | \
+    | sort -n "$@" | \
     sed -e 's,\([\-\+]\)0*\([123456789][[:digit:]]*\)_,\1\2_,' \
         -e 's,\([\-\+]\)00*_,_,'
 }


### PR DESCRIPTION
Small fixes for update-rc3 remove_image() changed by support for delivery of .gz files in lieu of uncompressed data