### PR TITLE
[PQSWPRG-7529] fty-db-engine.service + rcmysql-transient: smoother processing of system shutdown (vs usual service stop/restart)

### DIFF
--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -30,6 +30,7 @@ Restart=always
 # Note: explicit User=root is required for $HOME to get set and ~/.my.cnf
 # to get used by ExecStartPost self-check below
 User=root
+SyslogIdentifier=%n
 # Note: time below must suffice for units that require database to
 # have stopped before this service restarts, otherwise we get a
 # "failed to schedule restart job: Transaction is destructive" !

--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -4,6 +4,7 @@
 [Unit]
 Description=MySQL server for 42ity usage
 Conflicts=mysql.service mysqld.service mariadb.service
+Conflicts=shutdown.target halt.target poweroff.target reboot.target
 Wants=basic.target network.target
 
 Requires=fty-license-accepted.target

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -92,6 +92,7 @@ Conflicts=shutdown.target halt.target poweroff.target reboot.target
 
 [Service]
 ExecStopPost=/bin/systemctl stop --no-block fty-db-engine.service
+SyslogIdentifier=${TEMPORARY_UNIT_NAME}
 
 [Install]
 RequiredBy=fty-db-engine.service

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -110,8 +110,13 @@ EOF
                 [[ -L "/run/systemd/units/invocation:${TEMPORARY_UNIT_NAME}" ]] || exit
             done
         done )
-        echo "$0 $* finished `date -u`: ${TEMPORARY_UNIT_NAME} is no more" >&2
-        /bin/systemctl is-active "${TEMPORARY_UNIT_NAME}" >&2
+        if /bin/systemctl is-active "${TEMPORARY_UNIT_NAME}" >&2 ; then
+            echo "$0 $* finished `date -u`: ${TEMPORARY_UNIT_NAME} should be no more, but was reported active (code $?)" >&2
+            exit 1
+        else
+            echo "$0 $* finished `date -u`: ${TEMPORARY_UNIT_NAME} is no more" >&2
+            exit 0
+        fi
      ) &
     ;;
 stop)

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -122,6 +122,7 @@ EOF
 stop)
     RES=0
     rm -f "${TEMPORARY_UNIT_FILE_PATH}" || RES=$?
+    rm -f "/run/systemd/units/invocation:${TEMPORARY_UNIT_NAME}" ]] || RES=$?
     # Double-shot because sometimes systemctl misses :(
     /bin/systemctl stop --no-block "${TEMPORARY_UNIT_NAME}" || true ; sleep 3
     # Systemd tends to lock up when someone like us intrudes into a system

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -138,14 +138,14 @@ stop)
     /bin/systemctl list-jobs | egrep '^[0-9]* (((reboot|shutdown|poweroff|halt|final)\.target|systemd-reboot\.service) .*start|sysinit\.target .*stop)' && SHUTTINGDOWN=true
     if $SHUTTINGDOWN ; then
         # just let us go down as quickly as we can
-        echo "WARNING: Not waiting for '${TEMPORARY_UNIT_NAME}' to stop"
+        echo "WARNING: Shutting down now, not waiting for '${TEMPORARY_UNIT_NAME}' to stop"
     else
         /bin/systemctl stop "${TEMPORARY_UNIT_NAME}" || RES=$?
+        /bin/systemctl disable --runtime "${TEMPORARY_UNIT_NAME}" || RES=$?
+        rm -rf "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}.d" || RES=$?
+        rm -f "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}" || RES=$?
+        /bin/systemctl daemon-reload
     fi
-    /bin/systemctl disable --runtime "${TEMPORARY_UNIT_NAME}" || RES=$?
-    rm -rf "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}.d" || RES=$?
-    rm -f "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}" || RES=$?
-    /bin/systemctl daemon-reload
     exit $RES
     ;;
 status)

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -84,6 +84,10 @@ start)
     cat > "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}.d/fty-db-engine.conf" << EOF
 [Unit]
 PartOf=fty-db-engine.service
+# While technically fty-db-engine.service startup causes the ${TEMPORARY_UNIT_NAME}
+# to exist, we want systemd to chain and link their stop events "properly" -
+# so that this transient service gets removed to be redefined if needed later.
+Before=fty-db-engine.service
 Conflicts=shutdown.target halt.target poweroff.target reboot.target
 
 [Service]

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -127,7 +127,7 @@ EOF
 stop)
     RES=0
     rm -f "${TEMPORARY_UNIT_FILE_PATH}" || RES=$?
-    rm -f "/run/systemd/units/invocation:${TEMPORARY_UNIT_NAME}" ]] || RES=$?
+    #rm -f "/run/systemd/units/invocation:${TEMPORARY_UNIT_NAME}" ]] || RES=$?
     # Double-shot because sometimes systemctl misses :(
     /bin/systemctl stop --no-block "${TEMPORARY_UNIT_NAME}" || true ; sleep 3
     # Systemd tends to lock up when someone like us intrudes into a system

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -84,6 +84,7 @@ start)
     cat > "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}.d/fty-db-engine.conf" << EOF
 [Unit]
 PartOf=fty-db-engine.service
+Conflicts=shutdown.target halt.target poweroff.target reboot.target
 
 [Service]
 ExecStopPost=/bin/systemctl stop --no-block fty-db-engine.service

--- a/tools/rcmysql-transient
+++ b/tools/rcmysql-transient
@@ -119,7 +119,18 @@ stop)
     rm -f "${TEMPORARY_UNIT_FILE_PATH}" || RES=$?
     # Double-shot because sometimes systemctl misses :(
     /bin/systemctl stop --no-block "${TEMPORARY_UNIT_NAME}" || true ; sleep 3
-    /bin/systemctl stop "${TEMPORARY_UNIT_NAME}" || RES=$?
+    # Systemd tends to lock up when someone like us intrudes into a system
+    # shutdown in progress, unlike a usual service stop/restart event.
+    # In fact, the client locks up and does not actually trigger a stop of
+    # our transient service unit, until it is killed as stuck after 90s.
+    SHUTTINGDOWN=false
+    /bin/systemctl list-jobs | egrep '^[0-9]* (((reboot|shutdown|poweroff|halt|final)\.target|systemd-reboot\.service) .*start|sysinit\.target .*stop)' && SHUTTINGDOWN=true
+    if $SHUTTINGDOWN ; then
+        # just let us go down as quickly as we can
+        echo "WARNING: Not waiting for '${TEMPORARY_UNIT_NAME}' to stop"
+    else
+        /bin/systemctl stop "${TEMPORARY_UNIT_NAME}" || RES=$?
+    fi
     /bin/systemctl disable --runtime "${TEMPORARY_UNIT_NAME}" || RES=$?
     rm -rf "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}.d" || RES=$?
     rm -f "${SYSTEMD_RUN_UNITDIR}/${TEMPORARY_UNIT_NAME}" || RES=$?


### PR DESCRIPTION
Seems systemd still processes service stops (especially ones where an ExecStop, or a script called from one, calls `systemctl stop` for another) differently when the OS is shutting down vs. OS working and individual services "just" stopping for maintenance or to restart them. 

In case of OS shutdown, that systemctl client seems to lock up and does not tickle the other service in reality until the caller ends - which is a race. In case of usual living OS workflow, it just works flawlessly...

Since when knowingly shutting down we do not expect to restart services and dependencies in proper order during this ending uptime, we can forgo the wait for transient service stop from its wrapper and just let them both do what is needed to be done quickly. Note that the files being removed in "usual" case are located under `/run` temporary filesystem, so removing of cruft happens automatically by virtue of unmount and reboot.