### PR TITLE
tools/envvars-ExecStartPre.sh.in: report ENV_DHCP_CONFIG and ENV_DHCP_ACTIVE interface lists

### DIFF
--- a/tools/envvars-ExecStartPre.sh.in
+++ b/tools/envvars-ExecStartPre.sh.in
@@ -224,11 +224,11 @@ ENV_KNOWNFQDNS="$(list_fqdns | commatoze)"
 # Which interfaces are configured for DHCP, and which have an active
 # udhcpc client currently running?
 ### Note: assumes interface names end with a digit
-ENV_DHCP_ACTIVE="$(ps -ef | grep [u]dhcpc | sed 's,^.* -i \([^ ]*\)[^0-9]*.*$,\1,' | commatoze)"
+ENV_DHCP_ACTIVE="$(ps -ef | grep [u]dhcpc | grep ' -i ' | sed 's,^.* -i \([^ ]*\)[^0-9]*.*$,\1,' | commatoze_sorted)"
 ENV_DHCP_CONFIG=""
 if [ -n "$AUGOUT" ]; then
     ### Note: assumes augtool key-value results are separated by "<space><equals><space>"
-    ENV_DHCP_CONFIG="$(echo "$AUGOUT" | egrep '/method = dhcp$' | sed 's,/method = dhcp$,,' | while read I ; do echo "$AUGOUT" | fgrep "$I = " | sed 's,^.* *= *\([^ ]*\)$,\1,g'; done | commatoze)"
+    ENV_DHCP_CONFIG="$(echo "$AUGOUT" | egrep '/method = dhcp$' | sed 's,/method = dhcp$,,' | while read I ; do echo "$AUGOUT" | fgrep "$I = " | sed 's,^.* *= *\([^ ]*\)$,\1,g'; done | commatoze_sorted)"
 fi
 
 RES=255

--- a/tools/envvars-ExecStartPre.sh.in
+++ b/tools/envvars-ExecStartPre.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2014 - 2020 Eaton
+# Copyright (C) 2014 - 2021 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,10 +25,15 @@
 
 echo "Generate common run-time environment variables file for 42ity"
 
+# Standard time and tool outputs
 LANG=C
 LC_ALL=C
 TZ=UTC
 export LANG LC_ALL TZ
+
+# As an OS service (helper) this must use /bin/systemctl in its children in particular
+PATH="/sbin:/usr/sbin:/bin:/usr/bin:$PATH"
+export PATH
 
 set -e
 

--- a/tools/envvars-ExecStartPre.sh.in
+++ b/tools/envvars-ExecStartPre.sh.in
@@ -50,6 +50,31 @@ done
 [ -n "$OUTFILE" ] || OUTFILE="/run/fty-envvars.$OUTFMT"
 J="/etc/release-details.json"
 JO="/etc/bios-release.json" # Backwards compatibility
+
+### Several filtering routines follow which are used all over the place below
+### to help both readability and maintainability
+lowercase() {
+    tr '[A-Z]' '[a-z]'
+}
+
+space_to_linebreak() {
+    tr ' ' '\n'
+}
+
+commatoze() {
+    # Parse multi-line stdin and convert into a comma-separated single line
+    tr '\n' ',' | sed -e 's|,,|,|g' -e 's|^,*||' -e 's|,*$||'
+}
+
+sort_uniq() {
+    # Can pass "-r" for reverse sorting
+    sort -n "$@" | uniq
+}
+
+commatoze_sorted() {
+    sort_uniq "$@" | commatoze
+}
+
 echo "Make sure the current OS image name and other details are populated into '$OUTFILE'..."
 JSONSH="@datadir@/@PACKAGE@/scripts/JSON.sh"
 #JSONSH="/usr/share/bios/scripts/JSON.sh"
@@ -128,15 +153,15 @@ if [ -x /usr/bin/systemd-detect-virt ]; then
     VIRT_HYPERVIZOR="$(/usr/bin/systemd-detect-virt -v)" || true # not VIRT_HYPERVIZOR=""
 fi
 
-ENV_HOSTNAME="$(hostname | tr '[A-Z]' '[a-z]' )" || ENV_HOSTNAME=""
-ENV_DOMAINNAME="$(domainname | tr '[A-Z]' '[a-z]' | grep -v '(none)')" || ENV_DOMAINNAME=""
-ENV_DNSDOMAINNAME="$(dnsdomainname | tr '[A-Z]' '[a-z]' | grep -v '(none)')" || ENV_DNSDOMAINNAME=""
+ENV_HOSTNAME="$(hostname | lowercase )" || ENV_HOSTNAME=""
+ENV_DOMAINNAME="$(domainname | lowercase | grep -v '(none)')" || ENV_DOMAINNAME=""
+ENV_DNSDOMAINNAME="$(dnsdomainname | lowercase | grep -v '(none)')" || ENV_DNSDOMAINNAME=""
 # A one-per-line list of unique values for "domain" or "search" keywords
 # from /etc/resolv.conf; not exported at this time (see ENV_KNOWNDOMAINS)
-ENV_RESOLVDOMAINS="$(egrep '^[[:blank:]]*(search|domain)[[:blank:]]+' /etc/resolv.conf | while read K V ; do echo $V ; done | sed -e 's,[[:blank:]]+,\n,g' -e 's,\.$,,g' | tr '[A-Z]' '[a-z]' | sort | uniq)"
+ENV_RESOLVDOMAINS="$(egrep '^[[:blank:]]*(search|domain)[[:blank:]]+' /etc/resolv.conf | while read K V ; do echo $V ; done | sed -e 's,[[:blank:]]+,\n,g' -e 's,\.$,,g' | lowercase | sort_uniq)"
 # A comma-separated list (required for SQL magic, usable in shell) of
 # current non-loopback IP addresses, IPv4 and IPv6 alike, without masks
-ENV_IPADDRS="$(ip addr show | egrep '^[[:blank:]]*inet6?[[:blank:]]' | awk '{print $2}' | tr '[A-Z]' '[a-z]' | egrep -v '^(127\..*|0\.|255\.|::1/128)$' | sed 's,/[0-9]*$,,' | sort -nr | uniq | tr '\n' ',' | sed 's/,$//')" || ENV_IPADDRS=""
+ENV_IPADDRS="$(ip addr show | egrep '^[[:blank:]]*inet6?[[:blank:]]' | awk '{print $2}' | lowercase | egrep -v '^(127\..*|0\.|255\.|::1/128)$' | sed 's,/[0-9]*$,,' | commatoze_sorted -r)" || ENV_IPADDRS=""
 
 # Similarly, extract comma-separated lists of just IPv4 and IPv6 addresses
 ENV_IP4ADDRS=""
@@ -157,7 +182,7 @@ unset IFS_OLD
 # A comma-separated list of domain names (if any) that can be part of
 # this machine's FQDN when coupled with the hostname above. Note that
 # generally definition of "domain" is domain-dependent (pun intended).
-ENV_KNOWNDOMAINS="$(echo $ENV_DOMAINNAME $ENV_DNSDOMAINNAME $ENV_RESOLVDOMAINS | tr ' ' '\n' | sort -n | uniq | tr '\n' ',' | sed 's/,$//')"
+ENV_KNOWNDOMAINS="$(echo $ENV_DOMAINNAME $ENV_DNSDOMAINNAME $ENV_RESOLVDOMAINS | space_to_linebreak | commatoze_sorted)"
 
 list_hostnames_raw() {
     # Map known "this-host" IP addresses to known hostnames
@@ -167,7 +192,7 @@ list_hostnames_raw() {
 
 list_fqdns() {
     for H in `list_hostnames_raw` $ENV_HOSTNAME `cat /etc/hostname 2>/dev/null || true` ; do
-        H="`echo "$H" | tr '[A-Z]' '[a-z]'`"
+        H="`echo "$H" | lowercase`"
         case "$H" in
             localhost*|bios|loghost|mailhost) ;; # skip
             *.*) echo "$H" ;; # Already a dot-separated string
@@ -178,11 +203,11 @@ list_fqdns() {
                fi
                ;; # Generate dot-separated strings
         esac
-    done | tr '[A-Z]' '[a-z]' | sort | uniq
+    done | lowercase | sort_uniq
 }
 
 # A comma-separated list of this host's fully qualified domain names
-ENV_KNOWNFQDNS="$(list_fqdns | tr '\n' ',' | sed 's/,$//')"
+ENV_KNOWNFQDNS="$(list_fqdns | commatoze)"
 
 RES=255
 OUTFILE_ORIG="$OUTFILE"

--- a/tools/envvars-ExecStartPre.sh.in
+++ b/tools/envvars-ExecStartPre.sh.in
@@ -51,6 +51,14 @@ done
 J="/etc/release-details.json"
 JO="/etc/bios-release.json" # Backwards compatibility
 
+( which augtool >/dev/null ) || die $? "augtool must be in PATH"
+
+# By default, use our directory with a smaller selection of lenses to be faster
+AUGTOOL_ARGS=""
+if [ -d "@datadir@/@PACKAGE@/lenses" ] ; then
+    AUGTOOL_ARGS="-S -I@datadir@/@PACKAGE@/lenses"
+fi
+
 ### Several filtering routines follow which are used all over the place below
 ### to help both readability and maintainability
 lowercase() {
@@ -153,6 +161,10 @@ if [ -x /usr/bin/systemd-detect-virt ]; then
     VIRT_HYPERVIZOR="$(/usr/bin/systemd-detect-virt -v)" || true # not VIRT_HYPERVIZOR=""
 fi
 
+# Cache system interfaces config to parse below (augtool is expensive)
+AUGOUT="`(echo 'match /files/etc/network/interfaces/iface[*]'; echo 'match /files/etc/network/interfaces/auto[*]/*'; echo 'match /files/etc/network/interfaces/allow-hotplug[*]/*' ; echo 'match /files/etc/network/interfaces/iface[*]/method' ; echo 'match /files/etc/default/ifplugd/INTERFACES' ; echo 'match /files/etc/default/ifplugd/HOTPLUG_INTERFACES' ) | augtool $AUGTOOL_ARGS`" \
+&& [ -n "$AUGOUT" ] || AUGOUT=""
+
 ENV_HOSTNAME="$(hostname | lowercase )" || ENV_HOSTNAME=""
 ENV_DOMAINNAME="$(domainname | lowercase | grep -v '(none)')" || ENV_DOMAINNAME=""
 ENV_DNSDOMAINNAME="$(dnsdomainname | lowercase | grep -v '(none)')" || ENV_DNSDOMAINNAME=""
@@ -209,6 +221,16 @@ list_fqdns() {
 # A comma-separated list of this host's fully qualified domain names
 ENV_KNOWNFQDNS="$(list_fqdns | commatoze)"
 
+# Which interfaces are configured for DHCP, and which have an active
+# udhcpc client currently running?
+### Note: assumes interface names end with a digit
+ENV_DHCP_ACTIVE="$(ps -ef | grep [u]dhcpc | sed 's,^.* -i \([^ ]*\)[^0-9]*.*$,\1,' | commatoze)"
+ENV_DHCP_CONFIG=""
+if [ -n "$AUGOUT" ]; then
+    ### Note: assumes augtool key-value results are separated by "<space><equals><space>"
+    ENV_DHCP_CONFIG="$(echo "$AUGOUT" | egrep '/method = dhcp$' | sed 's,/method = dhcp$,,' | while read I ; do echo "$AUGOUT" | fgrep "$I = " | sed 's,^.* *= *\([^ ]*\)$,\1,g'; done | commatoze)"
+fi
+
 RES=255
 OUTFILE_ORIG="$OUTFILE"
 if [ -s "$OUTFILE" ]; then
@@ -233,6 +255,8 @@ ENV_DNSDOMAINNAME='${ENV_DNSDOMAINNAME}'
 ENV_IPADDRS='${ENV_IPADDRS}'
 ENV_IP4ADDRS='${ENV_IP4ADDRS}'
 ENV_IP6ADDRS='${ENV_IP6ADDRS}'
+ENV_DHCP_CONFIG='${ENV_DHCP_CONFIG}'
+ENV_DHCP_ACTIVE='${ENV_DHCP_ACTIVE}'
 ENV_KNOWNDOMAINS='${ENV_KNOWNDOMAINS}'
 ENV_KNOWNFQDNS='${ENV_KNOWNFQDNS}'
 EOF
@@ -254,6 +278,8 @@ set @ENV_DNSDOMAINNAME='${ENV_DNSDOMAINNAME}';
 set @ENV_IPADDRS='${ENV_IPADDRS}';
 set @ENV_IP4ADDRS='${ENV_IP4ADDRS}';
 set @ENV_IP6ADDRS='${ENV_IP6ADDRS}';
+set @ENV_DHCP_CONFIG='${ENV_DHCP_CONFIG}';
+set @ENV_DHCP_ACTIVE='${ENV_DHCP_ACTIVE}';
 set @ENV_KNOWNDOMAINS='${ENV_KNOWNDOMAINS}';
 set @ENV_KNOWNFQDNS='${ENV_KNOWNFQDNS}';
 EOF


### PR DESCRIPTION
Tested in a container with eth1 dhcp-served:

````
jim@ipm2-devel:~/FTY/fty-core$ ps -ef | grep dhc
root     26609     1  0 09:10 ?        00:00:00 /bin/busybox udhcpc -i eth1

jim@ipm2-devel:~/FTY/fty-core$ grep dhcp /etc/network/interfaces  
iface eth1 inet dhcp
````

First run with the new script (image-provided did not have features from this PR) only adds the new lines, did not break content of earlier data:
````
jim@ipm2-devel:~/FTY/fty-core$ sudo tools/envvars-ExecStartPre.sh
Generate common run-time environment variables file for 42ity
Make sure the current OS image name and other details are populated into '/run/fty-envvars.env'...
A /run/fty-envvars.env already exists, we will see below if its content is obsolete or not
--- /run/fty-envvars.env	2021-05-25 09:10:47.668498951 +0000
+++ /run/fty-envvars.env.tmp	2021-05-25 11:14:12.194429515 +0000
@@ -13,5 +13,7 @@
 ENV_IPADDRS='192.168.56.83,10.0.3.16,fe80::aede:48ff:fe1d:3201,fe80::aede:48ff:fe1d:3200'
 ENV_IP4ADDRS='192.168.56.83,10.0.3.16'
 ENV_IP6ADDRS='fe80::aede:48ff:fe1d:3201,fe80::aede:48ff:fe1d:3200'
+ENV_DHCP_CONFIG='eth1'
+ENV_DHCP_ACTIVE='eth1'
 ENV_KNOWNDOMAINS=''
 ENV_KNOWNFQDNS='ipm2-devel'
NOTE: Output was re-generated during this run and differs from what we had previously
Stashing previously generated file as /run/fty-envvars.env.prev
OK
````

Killing the DHCP client and retrying:
````
jim@ipm2-devel:~/FTY/fty-core$ sudo kill 26609
jim@ipm2-devel:~/FTY/fty-core$ sudo tools/envvars-ExecStartPre.sh
Generate common run-time environment variables file for 42ity
Make sure the current OS image name and other details are populated into '/run/fty-envvars.env'...
A /run/fty-envvars.env already exists, we will see below if its content is obsolete or not
--- /run/fty-envvars.env	2021-05-25 11:14:12.194429515 +0000
+++ /run/fty-envvars.env.tmp	2021-05-25 11:15:17.164617862 +0000
@@ -14,6 +14,6 @@
 ENV_IP4ADDRS='192.168.56.83,10.0.3.16'
 ENV_IP6ADDRS='fe80::aede:48ff:fe1d:3201,fe80::aede:48ff:fe1d:3200'
 ENV_DHCP_CONFIG='eth1'
-ENV_DHCP_ACTIVE='eth1'
+ENV_DHCP_ACTIVE=''
 ENV_KNOWNDOMAINS=''
 ENV_KNOWNFQDNS='ipm2-devel'
NOTE: Output was re-generated during this run and differs from what we had previously
Stashing previously generated file as /run/fty-envvars.env.prev
OK
````

Like for other data, several hits would be comma-separated:
````
:; udhcpc -i eth0 & udhcpc -i eth1 &
:; envvars-ExecStartPre.sh
...
+ENV_DHCP_ACTIVE='eth0,eth1'
...
````

So like for other purposes, the `/run/fty-envvars.env` can be sourced into a script (or EnvironmentFile of a service unit) and would set some envvars for that consumer to interpret.

Also note that data points in saved system config generally do not guarantee that this is the applied situation - dhcp client daemon can be killed and an address remains used "forever" (dhcp server might give it to someone else though), or someone manually sets `ifconfig eth0 1.2.3.4`, or someone manually uses `udhcpc -i eth1` for an interface persistently configured as static... So the script tries its best to report the current situation (known running dhcp client) and persistent config, any more correlation between that is speculative.