### PR TITLE
tools/ifupdown-force and bios-networking: track link state more diligently

### DIFF
--- a/tools/bios-networking
+++ b/tools/bios-networking
@@ -66,13 +66,14 @@ for IFACE in `ls -1 /sys/class/net/`; do
 
     (
     WAS_ADMIN_UP="$(ip link show ${IFACE} | grep '<' | sed -e 's,^.*<,,' -e 's,>.*$,,' | tr ',' '\n' | fgrep -x UP)" ; \
+    WAS_ADMIN_DOWN="$(ip link show ${IFACE} | grep '<' | sed -e 's,^.*<,,' -e 's,>.*$,,' | tr ',' '\n' | fgrep -x DOWN)" ; \
     ifdown --force $IFACE ;\
     if [ -s /run/udhcpc.${IFACE}.pid ]; then \
         kill -9 `cat /run/udhcpc.${IFACE}.pid`; \
         rm /run/udhcpc.${IFACE}.pid; \
     fi ;\
     sleep 5; \
-    [ "$WAS_ADMIN_UP" = "UP" ] && { ip link set $IFACE up ; sleep 5 ; } \
+    [ "$WAS_ADMIN_UP" = "UP" ] || [ -z "$WAS_ADMIN_DOWN" ] && { ip link set $IFACE up ; sleep 5 ; } \
     ifup --force $IFACE; \
     ) &
 done

--- a/tools/bios-networking
+++ b/tools/bios-networking
@@ -56,16 +56,23 @@ if [ "$NTP_SYSTEMD_ENABLED" = "enabled" ] ; then
 fi
 
 # restart all network interfaces except lo and kill dhcp client too
+# Note that (our) "ifdown --force" causes "ifconfig ... down" or equivalent
+# and then the "ethtool-static-nolink" called from "ifup" would refuse the
+# static interfaces. With WAS_ADMIN_UP below we track if the interface was
+# administratively-UP before we downed it, to restore this state before
+# requesting to configure it.
 for IFACE in `ls -1 /sys/class/net/`; do
     [ "${IFACE}" = "lo" ] && continue
 
     (
+    WAS_ADMIN_UP="$(ip link show ${IFACE} | grep '<' | sed -e 's,^.*<,,' -e 's,>.*$,,' | tr ',' '\n' | fgrep -x UP)" ; \
     ifdown --force $IFACE ;\
     if [ -s /run/udhcpc.${IFACE}.pid ]; then \
         kill -9 `cat /run/udhcpc.${IFACE}.pid`; \
         rm /run/udhcpc.${IFACE}.pid; \
     fi ;\
     sleep 5; \
+    [ "$WAS_ADMIN_UP" = "UP" ] && { ip link set $IFACE up ; sleep 5 ; } \
     ifup --force $IFACE; \
     ) &
 done

--- a/tools/ifupdown-force
+++ b/tools/ifupdown-force
@@ -33,14 +33,16 @@ case "$2" in
 up)
         # In some of the distros we use "ifup" tends to skip interfaces
         # that are not "UP" in the system. So make sure it is confgurable:
-        /sbin/ifconfig "$1" "$2"
+        /sbin/ifconfig "$1" "$2" || \
+        /sbin/ip link set "$1" "$2"
         { /sbin/ifup "$1" && { /sbin/ip address show dev "$1" | egrep '^\s*inet\s+[0-9]+\.+[0-9]+\.+[0-9]+\.+[0-9]+/[0-9]+|^\s*inet6\s.*:.*/' ; } ; } || \
         /sbin/ifup --force "$1"
         ;;
 down)
         /sbin/ifdown "$1" || \
         /sbin/ifdown --force "$1" || \
-        /sbin/ifconfig "$1" "$2"
+        /sbin/ifconfig "$1" "$2" || \
+        /sbin/ip link set "$1" "$2"
         # By this point, at best the interface is not-configured,
         # at worst it is just "DOWN" and the system does not use it
         ;;


### PR DESCRIPTION
On one hand, we have to disable the network interface when we deliberately `ifdown --force` it, because otherwise lingering DHCP clients and such tend to resurrect while we try to carefully restart networking. On another hand, our own tooling checks for disabled NICs with static addressing to avoid enabling administratively-down pre-configured back-up interfaces. Maybe this is why sometimes our testbeds end up without networking which is so easy to fix on console and neigh impossible remotely. Although they do use DHCP... in any case, bringing up the interface before configuring during the reconfig activity it should help.