### PR TITLE
[PQSWPRG-8035] preinstallimage-bios.sh.in: limit other aspects of acpid…

### DIFF
--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -1023,6 +1023,15 @@ EOF
 #/bin/systemctl enable nut-monitor.service
 /bin/systemctl enable nut.target
 
+# Since Debian Testing from sprint 2021, systemd acts up about acpid.service
+# which is excluded from running in containers. This worked okay for earlier
+# Debian iterations, but loops trying to start in the newer release (which
+# is a Debian 11 candidate). Per testing, adding the constraint to the .path
+# unit fixes the issue, and having it in .socket is further reassurance.
+mkdir -p /lib/systemd/system/acpid.path.d /lib/systemd/system/acpid.socket.d
+(echo '[Unit]'; echo 'ConditionVirtualization=!container') > /etc/systemd/system/acpid.path.d/constrain-not-container.conf
+ln /etc/systemd/system/acpid.path.d/constrain-not-container.conf /etc/systemd/system/acpid.socket.d/constrain-not-container.conf
+
 # according to https://github.com/42ity/malamute/blob/1.0-FTY-master/src/mlm_perftest.c#L22
 # "If we allow limits, then the engines will block under stress."
 # to avoid any block under stress, set unlimited High Water Mark on malamute clients side likes we have on the broker itself


### PR DESCRIPTION
…from starting in containers

This is something that has not visibly changed in config/unit/resource/... files between Debian 10 where it works okay (3 start attempts half a minute apart, and quiet) vs. recent Debian Testing where it loops 180 to 2000 times per second trying to start acpid.service and noticing it is not for containers, so blocking the startup - we do not get the getty prompt in a container in several hours. I think, but can't check anymore, that this was not the case in Debian Testing images built half a year ago. 

Whatever the reason, disabling the sibling acpid units does cause the main service to no longer loop trying to start, giving at least a symptomatic fix (imho root cause is in systemd) and allowing our D:T containers to boot all the way to the login.