### PR TITLE
Systemd service units: use "SyslogIdentifier=%N" to (hopefully) avoid…

### DIFF
--- a/systemd/bios-allowed.service
+++ b/systemd/bios-allowed.service
@@ -23,5 +23,6 @@ RequiredBy=bios-allowed.target
 #User=root
 Type=oneshot
 #Restart=no
+SyslogIdentifier=%N
 RemainAfterExit=yes
 ExecStart=/usr/bin/test ! -e /run/bios-shutdown.target.active

--- a/systemd/bios-enabler-pre.service
+++ b/systemd/bios-enabler-pre.service
@@ -14,6 +14,7 @@ RemainAfterExit=yes
 User=root
 #RestartSec=5
 TimeoutStartSec=15
+SyslogIdentifier=%N
 
 ExecStart=/bin/dash -c "for S in bios.target fty-db.target fty-license-accepted.target bios-pre-eula.target bios-allowed.target ; do [ xactive = x\"`/bin/systemctl is-active $S`\" ] && continue ; if ( [ xmasked = x\"`/bin/systemctl is-enabled $S`\" ] || [ xLoadState=masked = x\"`/bin/systemctl show -p LoadState $S`\" ] ) ; then /bin/systemctl unmask $S ; fi ; if [ xenabled != x\"`/bin/systemctl is-enabled $S`\" ] ; then /bin/systemctl enable $S ; fi; done; true"
 

--- a/systemd/bios-networking.service.in
+++ b/systemd/bios-networking.service.in
@@ -3,4 +3,5 @@ Description=Async restart of networking
 
 [Service]
 Type=simple
+SyslogIdentifier=%N
 ExecStart=@libexecdir@/@PACKAGE@/bios-networking

--- a/systemd/bios-reset-button.service.in
+++ b/systemd/bios-reset-button.service.in
@@ -7,6 +7,7 @@ DefaultDependencies=no
 Type=simple
 User=root
 Restart=always
+SyslogIdentifier=%N
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-@prefix@/share/fty/etc/default/fty

--- a/systemd/bios-shutdown.service
+++ b/systemd/bios-shutdown.service
@@ -18,6 +18,6 @@ User=root
 Type=oneshot
 Restart=no
 RemainAfterExit=yes
+SyslogIdentifier=%N
 ExecStart=/bin/touch /run/bios-shutdown.target.active
 ExecStop=/bin/rm -f /run/bios-shutdown.target.active
-

--- a/systemd/bios-ssh-last-resort.service.in
+++ b/systemd/bios-ssh-last-resort.service.in
@@ -4,6 +4,7 @@ After=auditd.service network.service
 
 [Service]
 EnvironmentFile=-/etc/default/ssh
+SyslogIdentifier=%N
 ExecStartPre=/usr/bin/ssh-keygen -A
 ExecStartPre=/bin/mkdir -p /run/sshd
 ExecStartPre=/bin/chmod 0755 /run/sshd

--- a/systemd/bios-target-watchdog.service.in
+++ b/systemd/bios-target-watchdog.service.in
@@ -16,6 +16,7 @@ Conflicts=bios-shutdown.target
 [Service]
 Type=oneshot
 RemainAfterExit=no
+SyslogIdentifier=%N
 
 # Tickle the target into starting regularly, which should cause
 # systemd attempts to start initially (or later) failed services.

--- a/systemd/bios.service
+++ b/systemd/bios.service
@@ -17,6 +17,7 @@ After=bios-enabler-pre.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+SyslogIdentifier=%N
 
 # Per systemd.service docs, TEMPFAIL exit code is 75 as used below
 # But Debian 8 systemd does not know the word, it seems. So we hardcode.

--- a/systemd/biostimer-compress-logs.service.in
+++ b/systemd/biostimer-compress-logs.service.in
@@ -4,6 +4,7 @@ Conflicts=rescue.target shutdown.target poweroff.target halt.target reboot.targe
 
 [Service]
 Type=simple
+SyslogIdentifier=%N
 ExecStart=@libexecdir@/@PACKAGE@/compress-logs
 
 [Install]

--- a/systemd/biostimer-loghost-rsyslog-netconsole.service.in
+++ b/systemd/biostimer-loghost-rsyslog-netconsole.service.in
@@ -8,6 +8,7 @@ Before=rsyslog.service
 
 [Service]
 Type=simple
+SyslogIdentifier=%N
 ExecStart=@libexecdir@/@PACKAGE@/loghost-rsyslog --netconsole
 
 [Install]

--- a/systemd/biostimer-verify-fs.service.in
+++ b/systemd/biostimer-verify-fs.service.in
@@ -6,6 +6,7 @@ After=rsyslogd.service syslog.socket
 
 [Service]
 Type=simple
+SyslogIdentifier=%N
 ExecStart=@libexecdir@/@PACKAGE@/verify-fs
 
 [Install]

--- a/systemd/fty-db-engine-pre.service.in
+++ b/systemd/fty-db-engine-pre.service.in
@@ -13,6 +13,7 @@ After=basic.target network.target fty-license-accepted.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+SyslogIdentifier=%N
 User=root
 #RestartSec=5
 TimeoutStartSec=15

--- a/systemd/fty-db-engine.service.in
+++ b/systemd/fty-db-engine.service.in
@@ -30,7 +30,7 @@ Restart=always
 # Note: explicit User=root is required for $HOME to get set and ~/.my.cnf
 # to get used by ExecStartPost self-check below
 User=root
-SyslogIdentifier=%n
+SyslogIdentifier=%N
 # Note: time below must suffice for units that require database to
 # have stopped before this service restarts, otherwise we get a
 # "failed to schedule restart job: Transaction is destructive" !

--- a/systemd/fty-db-init.service.in
+++ b/systemd/fty-db-init.service.in
@@ -17,6 +17,7 @@ PartOf=fty-db.target
 # trying to start up indefinitely (e.g. initial boot, untouched for days).
 Type=forking
 User=root
+SyslogIdentifier=%N
 # Unlimited startup...
 TimeoutStartSec=0
 # More than 90, less than in bios.service

--- a/systemd/fty-envvars.service.in
+++ b/systemd/fty-envvars.service.in
@@ -9,6 +9,7 @@ Type=oneshot
 # the service shall be considered active even when all its processes exited
 RemainAfterExit=yes
 Restart=no
+SyslogIdentifier=%N
 User=root
 Group=root
 ExecStart=@datadir@/@PACKAGE@/scripts/envvars-ExecStartPre.sh

--- a/systemd/fty-hostname-setup.service.in
+++ b/systemd/fty-hostname-setup.service.in
@@ -10,6 +10,7 @@ Before=network-online.target multi-user.target
 Type=oneshot
 # the service shall be considered active even when all its processes exited
 RemainAfterExit=yes
+SyslogIdentifier=%N
 Restart=no
 User=root
 Group=root

--- a/systemd/fty-license-accepted.service.in
+++ b/systemd/fty-license-accepted.service.in
@@ -26,6 +26,7 @@ Restart=no
 ###Restart=on-failure
 ###RestartSec=30m
 User=root
+SyslogIdentifier=%N
 ExecStartPre=/bin/dash -c "sleep 2 ; /usr/bin/test -s @ftydatadir@/fty-eula/license"
 ExecStart=/bin/dash -c "while ! /usr/bin/test -s @ftydatadir@/fty-eula/license ; do sleep 3 ; done"
 ExecStartPost=-/bin/systemctl start --no-block fty-license-accepted.target

--- a/systemd/fty-logrotate.service
+++ b/systemd/fty-logrotate.service
@@ -9,6 +9,7 @@ ConditionFileIsExecutable=/usr/sbin/logrotate
 Type=simple
 Restart=no
 User=root
+SyslogIdentifier=%N
 ExecStartPre=/bin/dash -c "if test -s /etc/logrotate.conf.dpkg-new && ! test -s /etc/logrotate.conf ; then mv -f /etc/logrotate.conf.dpkg-new /etc/logrotate.conf ; fi"
 ExecStart=/usr/sbin/logrotate /etc/logrotate.conf
 

--- a/systemd/fty-monitor-unlock.service
+++ b/systemd/fty-monitor-unlock.service
@@ -14,6 +14,7 @@ PartOf=bios.target
 Type=oneshot
 Restart=no
 User=root
+SyslogIdentifier=%N
 ExecStart=/usr/bin/passwd -u monitor
 ExecStart=/bin/sh -c "/bin/systemctl disable --no-ask-password %n ; /bin/systemctl mask --no-ask-password %n"
 

--- a/systemd/fty-tntnet@.service.in
+++ b/systemd/fty-tntnet@.service.in
@@ -7,9 +7,12 @@ PartOf=bios-pre-eula.target
 [Service]
 Type=simple
 Restart=always
+# Note: web server starts as root to grab ports, and changes to www-data
+# account (or whoever is configured in the instance's copy of tntnet.xml)
 User=root
 Group=root
 UMask=0000
+SyslogIdentifier=%N
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-@prefix@/share/fty/etc/default/fty

--- a/systemd/ifplug-dhcp-autoconf.service.in
+++ b/systemd/ifplug-dhcp-autoconf.service.in
@@ -15,6 +15,7 @@ Type=simple
 ### the service shall be considered active even when all its processes exited
 RemainAfterExit=yes
 User=root
+SyslogIdentifier=%N
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-@prefix@/share/fty/etc/default/fty

--- a/systemd/ipc-meta-setup.service.in
+++ b/systemd/ipc-meta-setup.service.in
@@ -9,6 +9,7 @@ Before = bios.target bios-pre-eula.target fty-db.target fty-license-accepted.tar
 [Service]
 Type = oneshot
 User = root
+SyslogIdentifier=%N
 ExecStart = @datadir@/@PACKAGE@/setup/ipc-meta-setup.sh
 RemainAfterExit = yes
 

--- a/systemd/wd_keepalive@.service
+++ b/systemd/wd_keepalive@.service
@@ -15,6 +15,7 @@ Type=forking
 User=root
 Restart=always
 RestartSec=2
+SyslogIdentifier=%N
 # We only need these configs for optional modules to probe
 # Otherwise we do not care much for that config in this simple
 # explicit-instance setup


### PR DESCRIPTION
… logging less identifiable "snoopy" or "sh" for helper scripting

* Not sure in which versions of systemd this should work, and blogs have varying opinions on whether this works only for some unit types (e.g. "forking" or not), but at least should not hurt to have this
* Regarding snoopy, opened issue 200 there - seems currently it handles syslog-style message sending on its own, so it should set the sender name (and that is not currently tweakable)
* For other subprocesses at least, the log should make sense better :)