### PR TITLE
Update existing Ext attribute

### DIFF
--- a/database/mysql/0024_batt_warranty_date.sql
+++ b/database/mysql/0024_batt_warranty_date.sql
@@ -1,0 +1,26 @@
+/* For details on schema version support see the main initdb.sql */
+SET @bios_db_schema_version = '202108270001' ;
+SET @bios_db_schema_filename = '0024_batt_warranty_date.sql' ;
+
+use box_utf8;
+
+
+/* This should be the first action in the SQL file */
+START TRANSACTION;
+INSERT INTO t_bios_schema_version (tag,timestamp,filename,version) VALUES('begin-import', UTC_TIMESTAMP() + 0, @bios_db_schema_filename, @bios_db_schema_version);
+/* Report the value */
+SELECT * FROM t_bios_schema_version WHERE tag = 'begin-import' order by id desc limit 1;
+COMMIT;
+
+/* Update existing Ext attribute from "battery_warranty_expiration_date"
+   to "battery.end_warranty_date" */
+UPDATE t_bios_asset_ext_attributes
+SET keytag = "battery.end_warranty_date"
+WHERE keytag = "battery_warranty_expiration_date";
+
+/* This must be the last line of the SQL file */
+START TRANSACTION;
+INSERT INTO t_bios_schema_version (tag,timestamp,filename,version) VALUES('finish-import', UTC_TIMESTAMP() + 0, @bios_db_schema_filename, @bios_db_schema_version);
+/* Report the value */
+SELECT * FROM t_bios_schema_version WHERE tag = 'finish-import' order by id desc limit 1;
+COMMIT;

--- a/database/mysql/Makefile.am
+++ b/database/mysql/Makefile.am
@@ -18,7 +18,8 @@ mysql_DATA	= initdb.sql \
 			0013_user_management.sql \
 			0014_user_preferences.sql \
 			0019_device_type_extension.sql \
-			0023_batt_maint_isodate.sql
+			0023_batt_maint_isodate.sql \
+			0024_batt_warranty_date.sql
 
 mysqlexdir	= $(datadir)/@PACKAGE@/examples/sql/mysql
 mysqlex_DATA	= \


### PR DESCRIPTION
Change from "battery_warranty_expiration_date" to
"battery.end_warranty_date", for coherence and generic
handling of alert (later)

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>