### PR TITLE
[IPMPROG-2421] tools/systemctl + start-db-services: manage ipm2 + ipm2-target-watchdog

### DIFF
--- a/tools/start-db-services.in
+++ b/tools/start-db-services.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2017 - 2020 Eaton
+# Copyright (C) 2017 - 2022 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -251,15 +251,44 @@ else
 fi
 echo "INFO: `date -u`: Done starting database services and their consumers: OK"
 
+# Note that the umbrella service may be already started (as dependency
+# of multi-user.target), so we explicitly poke the watchdog to surely
+# have it running
 echo "INFO: `date -u`: enable and start bios.service and bios.target for the remaining IPM Infra services"
 if [[ "$SYSTEMCTL_COALESCE" = no ]] ; then
     sudo ${SYSTEMCTL} enable bios.service
     sudo ${SYSTEMCTL} enable bios.target
     sudo ${SYSTEMCTL} start bios.service --no-block || die "Could not issue startup request for bios.service ($?)"
     sudo ${SYSTEMCTL} start bios.target --no-block || die "Could not issue startup request for bios.target ($?)"
+
+    # Note: no "enable" for the watchdogs, by design - only direct start
+    sudo ${SYSTEMCTL} start bios-target-watchdog.service --no-block || die "Could not issue startup request for bios-target-watchdog.service ($?)"
+    sudo ${SYSTEMCTL} start bios-target-watchdog.timer --no-block || die "Could not issue startup request for bios-target-watchdog.timer ($?)"
 else
     sudo ${SYSTEMCTL} enable bios.service bios.target
-    sudo ${SYSTEMCTL} start bios.service bios.target --no-block || die "Could not issue startup request for bios.target or bios.service ($?)"
+    sudo ${SYSTEMCTL} start bios.service bios.target bios-target-watchdog.service bios-target-watchdog.timer --no-block \
+    || die "Could not issue startup request for bios.target or bios.service or bios-target-watchdog.service or bios-target-watchdog.timer ($?)"
+fi
+
+if ${SYSTEMCTL} -a | grep ipm2 ; then
+  # NOTE: Compared to pure-FOSS 42ITy codebase, IPM2 and IPM Infra are
+  # value-added products and their components may be not present in a
+  # particular deployment. So attempts to enable/start are optional.
+  echo "INFO: `date -u`: try to enable and start ipm2.service and ipm2.target for the remaining IPM2 services"
+  if [[ "$SYSTEMCTL_COALESCE" = no ]] ; then
+    sudo ${SYSTEMCTL} enable ipm2.service
+    sudo ${SYSTEMCTL} enable ipm2.target
+    sudo ${SYSTEMCTL} start ipm2.service --no-block || die "Could not issue startup request for ipm2.service ($?)"
+    sudo ${SYSTEMCTL} start ipm2.target --no-block || die "Could not issue startup request for ipm2.target ($?)"
+
+    # Note: no "enable" for the watchdogs, by design - only direct start
+    sudo ${SYSTEMCTL} start ipm2-target-watchdog.service --no-block || die "Could not issue startup request for ipm2-target-watchdog.service ($?)"
+    sudo ${SYSTEMCTL} start ipm2-target-watchdog.timer --no-block || die "Could not issue startup request for ipm2-target-watchdog.timer ($?)"
+  else
+    sudo ${SYSTEMCTL} enable ipm2.service ipm2.target
+    sudo ${SYSTEMCTL} start ipm2.service ipm2.target ipm2-target-watchdog.service ipm2-target-watchdog.timer --no-block \
+    || die "Could not issue startup request for ipm2.target or ipm2.service or ipm2-target-watchdog.service or ipm2-target-watchdog.timer ($?)"
+  fi
 fi
 
 # NOTE: we have tntnet@bios.service officially aliased by fty-tntnet@bios.service

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -1,7 +1,7 @@
 #!/bin/bash
 # WARNING: bash syntax and capabilities are used intensively in code below!
 #
-# Copyright (C) 2015-2021 Eaton
+# Copyright (C) 2015-2022 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -78,6 +78,7 @@ SYSTEMCTL_UNITS_COMMON_EXTERNAL="mariadb mysql mysqld                   \
 SYSTEMCTL_UNITS_COMMON_INTERNAL="bios tntnet@bios fty-outage fty-metric-store   \
                                 fty-db bios-pre-eula bios-target-watchdog       \
                                 bios-allowed bios-shutdown                      \
+                                ipm2 ipm2-pre-eula ipm2-target-watchdog         \
                                 fty-tntnet@bios fty-envvars fty-hostname-setup  \
                                 fty-license-accepted fty-db-init fty-db-engine  \
                                 fty-kpi-power-uptime fty-alert-list fty-asset   \


### PR DESCRIPTION
Currently the chain of events in our OS images only activates bios-target-watchdog.timer and .service units, as prodded by (re-)evaluation of the bios.service after fty-license-accepted becomes active, but not their equivalent for ipm2. This causes value-added units to not restart automagically after failures, at least not until the first reboot after passing the EULA wizard.

CONTEXT: In case of smaller-scale failures outside the direct required-dependency propagation, such as restart of malamute which does not cause a fault/stop of ipm2.target (nor bios.target), units that do depend on the failed service (e.g. fty-asset or etn-amqp) stop... and then there is no systemd event to cause their start-up: such units are WantedBy the respective target, and target remains running un-interrupted. The bios-target-watchdog.timer fires regularly to execute bios-target-watchdog.service, which in turn tries to start everything in dependency tree for bios.target - this way an outage with downed services is limited in time.

This PR makes activation of bios-target-watchdog explicit, as well as "enables" it to auto-start with the system boot: currently it is explicitly optionally started by bios.service if FLA is active, but it should be always okay after the user passed EULA wizard once.

Also it newly attempts to enable+start the ipm2-target-watchdog (and IPM2 in general).