### PR TITLE
Fix diagnostic gathering

### DIFF
--- a/tools/diagnostic-information
+++ b/tools/diagnostic-information
@@ -148,7 +148,7 @@ running_processes() {
 ipm_services(){
     verbose "ipm services..."
     title 1 "IPM services"
-    for unit in $("${SYSTEMCTL}" list-ipm-units | grep -v "@.service"); do
+    for unit in $("${SYSTEMCTL}" list-ipm-units | grep -v -e "@.service" -e ".conf"); do
         title 2 "$unit"
         "${SYSTEMCTL}" status "$unit" | quote
     done
@@ -158,7 +158,7 @@ system_logs() {
     verbose "system logs..."
     mkdir -p "${WD}/${TMPDIR}/logs"
     cp -H -f /var/log/messages* "${WD}/${TMPDIR}/logs/"
-    cp -H -f /var/log/tntnet/www-audit* "${WD}/${TMPDIR}/logs/"
+    cp -H -f /var/log/app-audit/www-audit* "${WD}/${TMPDIR}/logs/"
 }
 
 ipm_logs() {

--- a/tools/systemctl
+++ b/tools/systemctl
@@ -66,7 +66,7 @@ JOURNALCTL_COMMANDS="-f --follow -l -u -fl -lf -fu -uf -lu -ul -flu -ful -luf -l
 # service named "bios-networking".
 # NOTE-DEV: Validate that this filter is still valid with "systemctl-uptodate"
 # SYSTEMCTL_UNITS_COMMON_EXTERNAL is a list of third-party services we rely on
-SYSTEMCTL_UNITS_COMMON_EXTERNAL="mariadb mysql mysqld                   \
+SYSTEMCTL_UNITS_COMMON_EXTERNAL="activemq@ipm2 mariadb mysql mysqld     \
                  ntp ntpd ntpdate sntp                                  \
                  networking network                                     \
                  nut-driver nut-monitor nut-server                      \


### PR DESCRIPTION
* List activemq@ipm2 part of the known allowed units
* Fix the path to www-audit.log

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>