### PR TITLE
Workaround the 128 chars limitation of sysctl.d

### DIFF
--- a/obs/debian.links
+++ b/obs/debian.links
@@ -1,0 +1,1 @@
+usr/libexec/bios/coredumper usb/sbin/coredumper

--- a/obs/preinstallimage-bios.sh.in
+++ b/obs/preinstallimage-bios.sh.in
@@ -79,8 +79,8 @@ if true; then
     mkdir -p /var/crash
     # By default, let all daemon users write here
     chmod 1777 /var/crash
-    ( if [ -x "/usr/libexec/bios/coredumper" ]; then
-        echo 'kernel.core_pattern='"`/usr/libexec/bios/coredumper --generate-core-pattern`"
+    ( if [ -x "/usr/sbin/coredumper" ]; then
+        echo 'kernel.core_pattern='"`/usr/sbin/coredumper --generate-core-pattern`"
         # Perhaps 0751 or 0750 for better security?
         chmod 0755 /var/crash
         # Our "admin" user should be a member of this group

--- a/tools/coredumper
+++ b/tools/coredumper
@@ -2,7 +2,7 @@
 # NOTE: Intentionally written for portable shell, no bashisms!
 
 #
-# Copyright (C) 2016 - 2021 Eaton
+# Copyright (C) 2016 - 2022 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 
 #! \file coredumper
 #  \author Jim Klimov <EvgenyKlimov@Eaton.com>
+#  \author Arnaud Quette <ArnaudQuette@Eaton.com>
 #  \brief  Process core files emitted by linux kernel
 #
 


### PR DESCRIPTION
sysctl.d file has a current practical limit of 128 chars, which results
in a truncated line for our coredump handler (kernel.core_pattern). Using
a symlink to our coredumper handler is simply a hotfix, and upstream
should be fixed as a better long run solution

Closes: IPMPROG-3983

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>