### PR TITLE
db-init.in : handle mariadb upgrade (tables compat.)

### DIFF
--- a/tools/db-init.in
+++ b/tools/db-init.in
@@ -543,6 +543,10 @@ esac
 
 ensure_root_password || exit $?
 
+# Handle mariadb upgrade (tables compatibility)
+# Do nothing if no upgrade needed
+mariadb-upgrade -u root
+
 # Note that BIOS_DB_INIT is very optional and mostly intended
 # for development. Production code does not set it.
 case "${BIOS_DB_INIT-}" in


### PR DESCRIPTION
=> fix issue on IPM upgrade

from 2.7.2 (debian 11/ mariadb 10.5.15)
to 2.8.0 (debian 12/ mariadb 10.11.6)
Handle internal system tables auto upgrade for the mysql server.

